### PR TITLE
chore: update version to 0.1.13 in Cargo.toml and tauri.conf.json

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dropout"
-version = "0.1.12"
+version = "0.1.13"
 edition = "2021"
 authors = ["HsiangNianian"]
 description = "The DropOut Minecraft Game Launcher"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
     "productName": "dropout",
-    "version": "0.1.12",
+    "version": "0.1.13",
     "identifier": "com.dropout.launcher",
     "build": {
         "beforeDevCommand": "pnpm -C ../ui dev",


### PR DESCRIPTION
## Summary by Sourcery

在与 Tauri 相关的配置文件中，将应用/包版本从 0.1.12 提升到 0.1.13。

构建：
- 将 Cargo 包版本更新为 0.1.13，以与新版本发布保持一致。
- 将 Tauri 配置中的版本引用更新为 0.1.13，用于桌面应用的构建。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bump the application/package version from 0.1.12 to 0.1.13 in Tauri-related configuration files.

Build:
- Update the Cargo package version to 0.1.13 to align with the new release.
- Update the Tauri configuration version reference to 0.1.13 for the desktop app build.

</details>