### PR TITLE
Revert "feat: add functionality to retrieve installed game versions"

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -587,48 +587,6 @@ async fn get_versions() -> Result<Vec<core::manifest::Version>, String> {
 }
 
 #[tauri::command]
-async fn get_installed_versions(app_handle: tauri::AppHandle) -> Result<Vec<String>, String> {
-    let game_dir = app_handle
-        .path()
-        .app_data_dir()
-        .map_err(|e| format!("Failed to get app data dir: {}", e))?;
-    
-    let versions_dir = game_dir.join("versions");
-
-    let entries = match std::fs::read_dir(&versions_dir) {
-        Ok(entries) => entries,
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
-            // No versions directory yet; treat as "no versions installed"
-            return Ok(Vec::new());
-        }
-        Err(e) => {
-            eprintln!(
-                "Failed to read versions directory {}: {}",
-                versions_dir.display(),
-                e
-            );
-            return Err(format!("Failed to read versions directory: {}", e));
-        }
-    };
-    
-    let installed_versions = entries
-        .flatten()
-        .filter(|entry| entry.file_type().map(|ft| ft.is_dir()).unwrap_or(false))
-        .filter_map(|entry| {
-            let file_name = entry.file_name().into_string().ok()?;
-            let json_path = entry.path().join(format!("{}.json", file_name));
-            if json_path.exists() {
-                Some(file_name)
-            } else {
-                None
-            }
-        })
-        .collect();
-    
-    Ok(installed_versions)
-}
-
-#[tauri::command]
 async fn login_offline(
     window: Window,
     state: State<'_, core::auth::AccountState>,
@@ -826,7 +784,6 @@ fn main() {
         .invoke_handler(tauri::generate_handler![
             start_game,
             get_versions,
-            get_installed_versions,
             login_offline,
             get_active_account,
             logout,

--- a/ui/src/components/BottomBar.svelte
+++ b/ui/src/components/BottomBar.svelte
@@ -65,13 +65,10 @@
       >
         {#if gameState.versions.length === 0}
           <option>Loading...</option>
-        {:else if gameState.installedVersionIds.length === 0}
-          <option disabled>No installed versions</option>
         {:else}
           {#each gameState.versions as version}
-            {#if gameState.installedVersionIds.includes(version.id)}
-              <option value={version.id}>{version.id} ({version.type})</option>
-            {/if}
+            <option value={version.id}>{version.id} ({version.type})</option
+            >
           {/each}
         {/if}
       </select>

--- a/ui/src/stores/game.svelte.ts
+++ b/ui/src/stores/game.svelte.ts
@@ -5,38 +5,14 @@ import { authState } from "./auth.svelte";
 
 export class GameState {
   versions = $state<Version[]>([]);
-  installedVersionIds = $state<string[]>([]);
   selectedVersion = $state("");
 
   async loadVersions() {
     try {
-      // Fetch both full version list and installed versions
-      const [allVersions, installedIds] = await Promise.all([
-        invoke<Version[]>("get_versions"),
-        invoke<string[]>("get_installed_versions")
-      ]);
-      
-      this.versions = allVersions;
-      this.installedVersionIds = installedIds;
-
-      if (this.installedVersionIds.length > 0) {
-        // Find the first installed version that appears in our manifest (preserving order)
-        // Usually we want the latest release that is installed
-        const installedVersions = this.versions.filter(v => this.installedVersionIds.includes(v.id));
-        
-        // Try to find latest release among installed
-        const latestInstalledRelease = installedVersions.find(v => v.type === "release");
-        
-        if (latestInstalledRelease) {
-          this.selectedVersion = latestInstalledRelease.id;
-        } else if (installedVersions.length > 0) {
-          this.selectedVersion = installedVersions[0].id;
-        } else {
-            // Fallback to just the first ID if not in manifest
-            this.selectedVersion = this.installedVersionIds[0];
-        }
-      } else {
-        this.selectedVersion = "";
+      this.versions = await invoke<Version[]>("get_versions");
+      if (this.versions.length > 0) {
+        const latest = this.versions.find((v) => v.type === "release");
+        this.selectedVersion = latest ? latest.id : this.versions[0].id;
       }
     } catch (e) {
       console.error("Failed to fetch versions:", e);


### PR DESCRIPTION
Reverts HsiangNianian/DropOut#16

## Summary by Sourcery

增强：
- 移除用于查询已安装游戏版本的后端命令和前端状态，从而简化版本加载逻辑和版本选择行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Remove the backend command and frontend state for querying installed game versions, simplifying version loading logic and selection behavior.

</details>