### PR TITLE
chore: bump version to 0.1.14 in Cargo.toml

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dropout"
-version = "0.1.13"
+version = "0.1.14"
 edition = "2021"
 authors = ["HsiangNianian"]
 description = "The DropOut Minecraft Game Launcher"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
     "productName": "dropout",
-    "version": "0.1.13",
+    "version": "0.1.14",
     "identifier": "com.dropout.launcher",
     "build": {
         "beforeDevCommand": "pnpm -C ../ui dev",


### PR DESCRIPTION
## Summary by Sourcery

杂务：
- 将 Cargo.toml 中的包版本从 0.1.13 更新为 0.1.14。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Chores:
- Update the Cargo.toml package version from 0.1.13 to 0.1.14.

</details>