### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,6 +10,9 @@ on:
     branches: ["main"]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
 


### PR DESCRIPTION
Potential fix for [https://github.com/HsiangNianian/DropOut/security/code-scanning/2](https://github.com/HsiangNianian/DropOut/security/code-scanning/2)

In general, the problem is fixed by explicitly setting a `permissions` block for the workflow or for individual jobs, reducing the `GITHUB_TOKEN` scope to the minimal rights needed (here, read-only access to repository contents). This avoids inheriting potentially broad default permissions (like read-write) from the repository or organization.

For this specific workflow, the simplest, non-breaking fix is to add a `permissions` block at the workflow root level (top-level key, aligned with `on:` and `jobs:`) that restricts permissions to `contents: read`. None of the steps require write access to the repo or other privileged scopes: they only check out the code, install dependencies, and run `cargo test` / `cargo build`. Adding the block near the top of the file also makes the intent obvious.

Concretely:
- Edit `.github/workflows/test.yml`.
- After the `on:` section (line 3–11) and before the `env:` block (line 13–15), insert:

```yaml
permissions:
  contents: read
```

No imports, new methods, or additional definitions are needed; this is a pure configuration change in the workflow file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## 由 Sourcery 提供的摘要

CI：
- 在测试工作流中添加显式的 permissions 配置块，将 GITHUB_TOKEN 的权限限制为仅可读取仓库内容。

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的摘要

CI：
- 在测试工作流中添加明确的 `permissions` 配置块，将 GITHUB_TOKEN 的权限限制为 `contents: read`。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

CI:
- Add an explicit permissions block to the test workflow to limit GITHUB_TOKEN to contents: read.

</details>

</details>