### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -13,6 +13,8 @@ on:
 
 jobs:
   check:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/HsiangNianian/DropOut/security/code-scanning/6](https://github.com/HsiangNianian/DropOut/security/code-scanning/6)

In general, the problem is fixed by explicitly defining a `permissions:` block that restricts the `GITHUB_TOKEN` to the minimal set of scopes required by the workflow. For workflows that only need to check out code and run local CI checks, `contents: read` at the workflow or job level is usually sufficient.

For this specific workflow, the `check` job uses `actions/checkout` (which needs read access to repo contents) and then runs local `pnpm` commands; there is no indication that it needs to write to the repository or interact with issues, PRs, or other resources. The best fix is to add a `permissions:` block with `contents: read`. To keep the change narrowly scoped and without altering behavior of other potential jobs in this workflow, we can add the block at the job level under `jobs.check`. Concretely, in `.github/workflows/check.yml`, insert:

```yaml
permissions:
  contents: read
```

between `check:` and `runs-on: ubuntu-latest`. No additional methods, imports, or definitions are needed, as this is pure workflow configuration.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

CI：
- 在检查工作流中添加作业级的 `permissions` 配置块，为仓库内容授予只读访问权限。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

CI:
- Add a job-level permissions block granting read-only access to repository contents in the check workflow.

</details>
- 在 GitHub Actions 工作流中，为 check 任务显式添加只读的 `contents` 权限。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

CI：
- 在检查工作流中添加作业级的 `permissions` 配置块，为仓库内容授予只读访问权限。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

CI:
- Add a job-level permissions block granting read-only access to repository contents in the check workflow.

</details>

</details>