### PR TITLE
Potential fix for code scanning alert no. 3: Cleartext logging of sensitive information

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -83,13 +83,9 @@ async fn start_game(
         .clone()
         .ok_or("No active account found. Please login first.")?;
 
-    let account_type = match &account {
-        core::auth::Account::Offline(_) => "Offline",
-        core::auth::Account::Microsoft(_) => "Microsoft",
-    };
     emit_log!(
         window,
-        format!("Account found: {} ({})", account.username(), account_type)
+        format!("Account found: {}", account.username())
     );
 
     let config = config_state.config.lock().unwrap().clone();


### PR DESCRIPTION
Potential fix for [https://github.com/HsiangNianian/DropOut/security/code-scanning/3](https://github.com/HsiangNianian/DropOut/security/code-scanning/3)

General approach: Avoid logging sensitive or potentially sensitive authentication details in cleartext. In this case, the flagged field is `account_type`, so we should modify the log message to omit that value (or replace it with a generalized, non-user-specific message) while keeping behavior otherwise identical. We do not need encryption here; simply removing the sensitive value is enough.

Best concrete fix: Update the `emit_log!` call around lines 90–93 so it no longer includes `account_type`. The function only uses `account_type` to build the log message; no other logic depends on it, so we can either (a) keep the variable unused (and accept a compiler warning) or (b) remove the variable entirely and log only the username. To keep the code clean, we can log just `"Account found: <username>"` and remove the `account_type` variable since it’s no longer needed. This change affects only the snippet shown in `src-tauri/src/main.rs`; no imports or additional methods are required.

Concretely:
- In `src-tauri/src/main.rs`, remove the `let account_type = ...` match block and simplify the subsequent `emit_log!` to log only the username:
  - Replace lines 86–93 (match + emit_log) with a single `emit_log!` call using `account.username()` only.
- No additional dependencies or imports are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

错误修复：
- 停止在“Account found”日志消息中包含账户类型，以解决明文日志记录的安全警报。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Stop including account type in the "Account found" log message to address a cleartext logging security alert.

</details>
- 不再在“Account found”日志消息中包含账户类型，只记录用户名。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

错误修复：
- 停止在“Account found”日志消息中包含账户类型，以解决明文日志记录的安全警报。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Stop including account type in the "Account found" log message to address a cleartext logging security alert.

</details>

</details>