### PR TITLE
fix(ci): Enable cross compilation for musl builds and streamline dependency installation

### DIFF
--- a/.github/workflows/semifold-ci.yaml
+++ b/.github/workflows/semifold-ci.yaml
@@ -28,6 +28,7 @@ jobs:
             name: "Linux x86_64 (Musl)"
             target: "x86_64-unknown-linux-musl"
             args: "--target x86_64-unknown-linux-musl"
+            use-cross: true
           - platform: "ubuntu-24.04-arm"
             name: "Linux arm64"
             target: "aarch64-unknown-linux-gnu"
@@ -65,9 +66,6 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y libwebkit2gtk-4.1-dev build-essential curl wget file libssl-dev libgtk-3-dev libayatana-appindicator3-dev librsvg2-dev libfuse2
-          if [ "${{ matrix.target }}" = "x86_64-unknown-linux-musl" ]; then
-            sudo apt-get install -y musl-tools pkg-config
-          fi
 
       - name: Install pnpm
         uses: pnpm/action-setup@v4
@@ -86,6 +84,10 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ matrix.target }}
+
+      - name: Install cross (for musl builds)
+        if: matrix.use-cross == true
+        run: cargo install cross
 
       - name: Rust Cache
         uses: swatinem/rust-cache@v2
@@ -109,9 +111,10 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RUSTFLAGS: ${{ matrix.rustflags || '' }}
-          PKG_CONFIG_PATH: ${{ (matrix.target == 'x86_64-unknown-linux-musl') && '/usr/lib/x86_64-linux-musl/pkgconfig' || '' }}
+          CARGO_BUILD_TARGET: ${{ matrix.target }}
         with:
           args: ${{ matrix.args }}
+          command: ${{ matrix.use-cross && 'cross' || 'cargo' }}
 
       - name: Fix AppImage for Wayland (Linux)
         if: startsWith(matrix.platform, 'ubuntu') && !startsWith(matrix.platform, 'macos') && !startsWith(matrix.platform, 'windows')


### PR DESCRIPTION
## Summary by Sourcery

Extend CI packaging matrix and enable cross compilation for new musl and GNU targets.

New Features:
- Add Linux x86_64 musl and Windows x86_64 GNU targets to the Tauri packaging matrix.

Enhancements:
- Trigger the Semifold CI workflow on both main and dev branches.
- Install and use the cross tool for musl builds to support cross compilation in CI.
- Pass per-target RUSTFLAGS and CARGO_BUILD_TARGET into the Tauri action and select cargo vs cross based on the matrix configuration.