### PR TITLE
revert: revert due to aur release

### DIFF
--- a/.changes/release-aur.md
+++ b/.changes/release-aur.md
@@ -1,0 +1,5 @@
+---
+dropout: "patch:chore"
+---
+
+Release Dropout to AUR.

--- a/src-tauri/CHANGELOG.md
+++ b/src-tauri/CHANGELOG.md
@@ -1,11 +1,5 @@
 # Changelog
 
-## v0.2.0-alpha.3
-
-### Chores
-
-- [`7edccaf`](https://github.com/HydroRoll-Team/DropOut/commit/7edccaf1be357c0a2619a87bc1767bc6c8a95954): Release Dropout to AUR.
-
 ## v0.2.0-alpha.2
 
 ### New Features

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dropout"
-version = "0.2.0-alpha.3"
+version = "0.2.0-alpha.2"
 edition = "2024"
 authors = ["HsiangNianian"]
 description = "The DropOut Minecraft Game Launcher"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "productName": "dropout",
-  "version": "0.2.0-alpha.3",
+  "version": "0.2.0-alpha.2",
   "identifier": "com.dropout.launcher",
   "build": {
     "beforeDevCommand": "pnpm --filter @dropout/ui dev",


### PR DESCRIPTION
Reverts HydroRoll-Team/DropOut#102

## Summary by Sourcery

Revert the Dropout v0.2.0-alpha.3 release metadata and move the AUR release note into the changeset system.

Build:
- Roll back the Tauri package version from v0.2.0-alpha.3 to v0.2.0-alpha.2 and adjust release notes accordingly.

Chores:
- Record the AUR release of Dropout as a changeset entry instead of a changelog section.