### PR TITLE
revert: aur release failed caused by product name change

### DIFF
--- a/.changes/release-aur.md
+++ b/.changes/release-aur.md
@@ -1,0 +1,5 @@
+---
+dropout: "patch:chore"
+---
+
+Release Dropout to AUR.

--- a/.changes/tauri-app-name.md
+++ b/.changes/tauri-app-name.md
@@ -1,0 +1,5 @@
+---
+dropout: "patch:feat"
+---
+
+Improve tauri app name from `dropout` to `Dropout Launcher`.

--- a/src-tauri/CHANGELOG.md
+++ b/src-tauri/CHANGELOG.md
@@ -1,15 +1,5 @@
 # Changelog
 
-## v0.2.0-alpha.3
-
-### Chores
-
-- [`7edccaf`](https://github.com/HydroRoll-Team/DropOut/commit/7edccaf1be357c0a2619a87bc1767bc6c8a95954): Release Dropout to AUR.
-
-### New Features
-
-- [`26f299f`](https://github.com/HydroRoll-Team/DropOut/commit/26f299f1e2da116a8702a87e887e17ba3f822d64): Improve tauri app name from `dropout` to `Dropout Launcher`.
-
 ## v0.2.0-alpha.2
 
 ### New Features

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dropout"
-version = "0.2.0-alpha.3"
+version = "0.2.0-alpha.2"
 edition = "2024"
 authors = ["HsiangNianian"]
 description = "The DropOut Minecraft Game Launcher"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "productName": "Dropout Launcher",
-  "version": "0.2.0-alpha.3",
+  "version": "0.2.0-alpha.2",
   "identifier": "com.dropout.launcher",
   "build": {
     "beforeDevCommand": "pnpm --filter @dropout/ui dev",


### PR DESCRIPTION
Reverts HydroRoll-Team/DropOut#105

## Summary by Sourcery

Revert the previous Tauri app release changes that bumped the version and renamed the app for AUR distribution.

New Features:
- Remove the previously introduced Tauri app name change from `dropout` to `Dropout Launcher`.

Enhancements:
- Revert the Cargo package version from 0.2.0-alpha.3 back to 0.2.0-alpha.2 and move the corresponding release notes into the changeset files.

Chores:
- Restore the project state prior to the attempted AUR release and track those changes as separate changeset entries.