### PR TITLE
chore: move pnpm config to workspace file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,5 @@ release/
 
 # Vscode
 .vscode/
+
+.pnpm-store/

--- a/package.json
+++ b/package.json
@@ -28,28 +28,5 @@
     "@tauri-apps/cli": "^2.9.6",
     "@types/node": "^24.10.9",
     "tsx": "^4.21.0"
-  },
-  "pnpm": {
-    "overrides": {
-      "vite": "npm:rolldown-vite@^7",
-      "axios": "1.13.5",
-      "dompurify": "3.3.2",
-      "express-rate-limit": "8.2.2",
-      "hono": "4.12.4",
-      "@hono/node-server": "1.19.10",
-      "@isaacs/brace-expansion": "5.0.1",
-      "lodash": "4.17.23",
-      "minimatch": "10.2.3",
-      "path-to-regexp": "0.1.13",
-      "picomatch": "2.3.2",
-      "qs": "6.14.2",
-      "seroval": "1.4.1"
-    },
-    "onlyBuiltDependencies": [
-      "@j178/prek",
-      "core-js",
-      "esbuild",
-      "msw"
-    ]
   }
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,23 @@
 packages:
   - packages/*
+
+overrides:
+  vite: npm:rolldown-vite@^7
+  axios: 1.13.5
+  dompurify: 3.3.2
+  express-rate-limit: 8.2.2
+  hono: 4.12.4
+  "@hono/node-server": 1.19.10
+  "@isaacs/brace-expansion": 5.0.1
+  lodash: 4.17.23
+  minimatch: 10.2.3
+  path-to-regexp: 0.1.13
+  picomatch: 2.3.2
+  qs: 6.14.2
+  seroval: 1.4.1
+
+onlyBuiltDependencies:
+  - "@j178/prek"
+  - core-js
+  - esbuild
+  - msw


### PR DESCRIPTION
## Summary by Sourcery

Build:
- Relocate pnpm overrides and onlyBuiltDependencies settings from package.json to pnpm-workspace.yaml for centralized workspace-level configuration.