### PR TITLE
Finalize Cloudflare deployment CI

### DIFF
--- a/.github/workflows/production-smoke.yml
+++ b/.github/workflows/production-smoke.yml
@@ -12,6 +12,11 @@ on:
   schedule:
     - cron: "17 2 * * *"
   workflow_dispatch:
+    inputs:
+      base_url:
+        description: Smoke target base URL
+        required: false
+        default: https://dropout.opensource-d6b.workers.dev
 
 permissions:
   checks: read
@@ -24,7 +29,7 @@ jobs:
     timeout-minutes: 15
 
     env:
-      BASE_URL: https://dropout.hydroroll.team
+      BASE_URL: ${{ github.event.inputs.base_url || 'https://dropout.opensource-d6b.workers.dev' }}
 
     steps:
       - name: Wait for Cloudflare Workers build

--- a/.github/workflows/production-smoke.yml
+++ b/.github/workflows/production-smoke.yml
@@ -1,0 +1,105 @@
+name: Production Smoke Check
+
+on:
+  push:
+    branches: ["main", "dev"]
+    paths:
+      - "packages/docs/**"
+      - "wrangler.jsonc"
+      - ".github/workflows/production-smoke.yml"
+      - "package.json"
+      - "pnpm-lock.yaml"
+  schedule:
+    - cron: "17 2 * * *"
+  workflow_dispatch:
+
+permissions:
+  checks: read
+  contents: read
+
+jobs:
+  smoke:
+    name: Smoke dropout.hydroroll.team
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    env:
+      BASE_URL: https://dropout.hydroroll.team
+
+    steps:
+      - name: Wait for Cloudflare Workers build
+        if: github.event_name == 'push'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          for attempt in {1..40}; do
+            result="$(
+              gh api "repos/${GITHUB_REPOSITORY}/commits/${GITHUB_SHA}/check-runs" \
+                --jq '[.check_runs[] | select(.name == "Workers Builds: dropout")] | first | if . == null then empty else "\(.status) \(.conclusion // "pending")" end' \
+                2>/dev/null || true
+            )"
+
+            if [ -n "$result" ]; then
+              echo "Workers Builds: dropout => $result"
+              status="${result%% *}"
+              conclusion="${result#* }"
+
+              if [ "$status" = "completed" ]; then
+                test "$conclusion" = "success"
+                exit 0
+              fi
+            else
+              echo "Workers Builds: dropout check not found yet"
+            fi
+
+            sleep 15
+          done
+
+          echo "Timed out waiting for Cloudflare Workers build"
+          exit 1
+
+      - name: Check production routes
+        run: |
+          set -euo pipefail
+
+          check_route() {
+            path="$1"
+            expected_status="$2"
+            expected_type="$3"
+            url="${BASE_URL}${path}"
+
+            for attempt in {1..12}; do
+              result="$(
+                curl -sS -L \
+                  --connect-timeout 10 \
+                  --max-time 30 \
+                  -o /tmp/dropout-smoke-body \
+                  -w "%{http_code} %{content_type}" \
+                  "$url" || true
+              )"
+
+              status="${result%% *}"
+              content_type="${result#* }"
+
+              if [ "$status" = "$expected_status" ] && [[ "$content_type" == "$expected_type"* ]]; then
+                echo "ok $path => $status $content_type"
+                return 0
+              fi
+
+              echo "attempt $attempt failed for $path: got ${status:-curl-failed} ${content_type:-unknown}, expected $expected_status $expected_type"
+              sleep 10
+            done
+
+            echo "Production smoke check failed for $url"
+            echo "--- response body preview ---"
+            head -c 2000 /tmp/dropout-smoke-body || true
+            exit 1
+          }
+
+          check_route "/" "200" "text/html"
+          check_route "/image.png" "200" "image/png"
+          check_route "/docs/manual/getting-started" "200" "text/html"
+          check_route "/en/docs/manual/getting-started" "200" "text/html"
+          check_route "/manual" "404" "text/html"

--- a/.github/workflows/semifold-ci.yaml
+++ b/.github/workflows/semifold-ci.yaml
@@ -26,7 +26,7 @@ jobs:
             name: "Linux x86_64 (GNU)"
             target: "x86_64-unknown-linux-gnu"
             args: "--target x86_64-unknown-linux-gnu"
-          - platform: "ubuntu-24.04-arm"
+          - platform: "ubuntu-22.04-arm"
             name: "Linux arm64 (GNU)"
             target: "aarch64-unknown-linux-gnu"
             args: "--target aarch64-unknown-linux-gnu"
@@ -55,6 +55,7 @@ jobs:
 
       - name: Install Dependencies (Linux)
         if: runner.os == 'Linux'
+        timeout-minutes: 15
         run: |
           sudo tee /etc/apt/apt.conf.d/99github-actions-retries >/dev/null <<'EOF'
           Acquire::Retries "5";

--- a/.github/workflows/semifold-ci.yaml
+++ b/.github/workflows/semifold-ci.yaml
@@ -56,8 +56,22 @@ jobs:
       - name: Install Dependencies (Linux)
         if: runner.os == 'Linux'
         run: |
-          sudo apt-get update
-          sudo apt-get install -y libwebkit2gtk-4.1-dev build-essential curl wget file libssl-dev libgtk-3-dev libayatana-appindicator3-dev librsvg2-dev libfuse2
+          sudo tee /etc/apt/apt.conf.d/99github-actions-retries >/dev/null <<'EOF'
+          Acquire::Retries "5";
+          Acquire::ForceIPv4 "true";
+          Acquire::http::Timeout "30";
+          Acquire::https::Timeout "30";
+          EOF
+
+          packages="libwebkit2gtk-4.1-dev build-essential curl wget file libssl-dev libgtk-3-dev libayatana-appindicator3-dev librsvg2-dev libfuse2"
+          for attempt in 1 2 3; do
+            sudo apt-get update && sudo apt-get install -y $packages && break
+            if [ "$attempt" = "3" ]; then
+              exit 1
+            fi
+            sudo apt-get clean
+            sleep $((attempt * 15))
+          done
 
       - name: Install Musl Tools (for musl target)
         if: matrix.install-musl == true

--- a/.github/workflows/semifold-ci.yaml
+++ b/.github/workflows/semifold-ci.yaml
@@ -104,7 +104,7 @@ jobs:
       - name: Rust Cache
         uses: swatinem/rust-cache@v2
         with:
-          shared-key: ${{ matrix.target }}
+          shared-key: ${{ matrix.platform }}-${{ matrix.target }}
 
       - name: Setup appimagetool (Linux)
         if: startsWith(matrix.platform, 'ubuntu') && !startsWith(matrix.platform, 'macos') && !startsWith(matrix.platform, 'windows')

--- a/README.CN.md
+++ b/README.CN.md
@@ -132,6 +132,8 @@ UI 可以在浏览器中用于布局开发，但依赖 Tauri 的功能需要在�
 | 运行文档站 | `pnpm -C packages/docs dev` |
 | 构建文档站 | `pnpm -C packages/docs build` |
 | 检查文档类型/内容 | `pnpm -C packages/docs types:check` |
+| 验证 Cloudflare 文档站部署 | `pnpm exec wrangler deploy --dry-run` |
+| 部署文档站到 Cloudflare Workers | `pnpm exec wrangler deploy` |
 | 测试 Rust workspace | `cargo test --workspace` |
 
 ---

--- a/README.md
+++ b/README.md
@@ -132,6 +132,8 @@ The UI can run in a browser for layout work, but Tauri-backed flows require the 
 | Run docs site | `pnpm -C packages/docs dev` |
 | Build docs site | `pnpm -C packages/docs build` |
 | Check docs types/content | `pnpm -C packages/docs types:check` |
+| Validate Cloudflare docs deploy | `pnpm exec wrangler deploy --dry-run` |
+| Deploy docs to Cloudflare Workers | `pnpm exec wrangler deploy` |
 | Test Rust workspace | `cargo test --workspace` |
 
 ---

--- a/packages/docs/README.md
+++ b/packages/docs/README.md
@@ -132,14 +132,20 @@ Keep commands copyable and exact. If a command must be run from the repo root or
 
 ## Deployment
 
-The docs package builds to `build/`:
+The docs site is deployed as a Cloudflare Worker with static assets. The root
+`wrangler.jsonc` is the source of truth for the Worker name, build command,
+asset binding, compatibility date, and observability settings.
 
 ```bash
+pnpm -C packages/docs --lockfile-dir "$PWD" install
 pnpm -C packages/docs build
-pnpm -C packages/docs start
+pnpm exec wrangler deploy --dry-run
+pnpm exec wrangler deploy
 ```
 
-Repository CI should run the same build and type/content checks before publishing the site.
+Use `pnpm -C packages/docs start` only for checking the Node server build
+locally. Production traffic should go through Cloudflare Workers, not Vercel or
+GitHub Pages.
 
 ---
 

--- a/packages/docs/app/docs/page.tsx
+++ b/packages/docs/app/docs/page.tsx
@@ -5,7 +5,7 @@ import { DocsLayout } from "fumadocs-ui/layouts/docs";
 import defaultMdxComponents from "fumadocs-ui/mdx";
 import { DocsBody, DocsPage } from "fumadocs-ui/page";
 import { Mermaid } from "@/components/mermaid";
-import { i18n } from "@/lib/i18n";
+import { resolveLocale } from "@/lib/i18n";
 import { baseOptions } from "@/lib/layout.shared";
 import { source } from "@/lib/source";
 import type { Route } from "./+types/page";
@@ -14,11 +14,11 @@ export async function loader({ params }: Route.LoaderArgs) {
   // 从路由参数获取语言，如果没有则使用默认语言
   // URL 格式: /docs/manual/getting-started (默认语言 zh)
   // URL 格式: /en/docs/manual/getting-started (英语)
-  const lang: "zh" | "en" =
-    params.lang &&
-    i18n.languages.includes(params.lang as (typeof i18n)["languages"][number])
-      ? (params.lang as "zh" | "en")
-      : (i18n.defaultLanguage as "zh" | "en");
+  const lang = resolveLocale(params.lang);
+
+  if (lang === null) {
+    throw new Response("Not found", { status: 404 });
+  }
 
   // 获取文档路径 slugs
   const slugs = params["*"]?.split("/").filter((v) => v.length > 0) || [];

--- a/packages/docs/app/entry.server.tsx
+++ b/packages/docs/app/entry.server.tsx
@@ -1,0 +1,21 @@
+import { renderToReadableStream } from "react-dom/server.browser";
+import type { EntryContext } from "react-router";
+import { ServerRouter } from "react-router";
+
+export default async function handleRequest(
+  request: Request,
+  responseStatusCode: number,
+  responseHeaders: Headers,
+  routerContext: EntryContext,
+) {
+  const body = await renderToReadableStream(
+    <ServerRouter context={routerContext} url={request.url} />,
+  );
+
+  responseHeaders.set("Content-Type", "text/html");
+
+  return new Response(body, {
+    headers: responseHeaders,
+    status: responseStatusCode,
+  });
+}

--- a/packages/docs/app/lib/i18n.ts
+++ b/packages/docs/app/lib/i18n.ts
@@ -6,3 +6,13 @@ export const i18n = defineI18n({
   hideLocale: "default-locale",
   parser: "dir", // 使用目录结构 (content/zh/*, content/en/*)
 });
+
+export type Locale = (typeof i18n.languages)[number];
+
+export function resolveLocale(value: string | undefined): Locale | null {
+  if (!value) {
+    return i18n.defaultLanguage as Locale;
+  }
+
+  return i18n.languages.includes(value as Locale) ? (value as Locale) : null;
+}

--- a/packages/docs/app/routes/docs.tsx
+++ b/packages/docs/app/routes/docs.tsx
@@ -1,12 +1,16 @@
 import { redirect } from "react-router";
-import { i18n } from "@/lib/i18n";
+import { i18n, resolveLocale } from "@/lib/i18n";
 import type { Route } from "./+types/docs";
 
 export function loader({ params }: Route.LoaderArgs) {
-  const lang = params.lang as string | undefined;
+  const lang = resolveLocale(params.lang);
+
+  if (lang === null) {
+    throw new Response("Not found", { status: 404 });
+  }
 
   // 如果没有语言参数或是默认语言，重定向到 /docs/manual/getting-started
-  if (!lang || lang === i18n.defaultLanguage) {
+  if (lang === i18n.defaultLanguage) {
     return redirect("/docs/manual/getting-started");
   }
 

--- a/packages/docs/app/routes/home.tsx
+++ b/packages/docs/app/routes/home.tsx
@@ -1,5 +1,5 @@
 import { HomeLayout } from "fumadocs-ui/layouts/home";
-import { i18n } from "@/lib/i18n";
+import { i18n, resolveLocale } from "@/lib/i18n";
 import { baseOptions } from "@/lib/layout.shared";
 import type { Route } from "./+types/home";
 
@@ -121,8 +121,16 @@ export function meta() {
   ];
 }
 
+export function loader({ params }: Route.LoaderArgs) {
+  if (resolveLocale(params.lang) === null) {
+    throw new Response("Not found", { status: 404 });
+  }
+
+  return null;
+}
+
 export default function Home({ params }: Route.ComponentProps) {
-  const lang = (params.lang as "en" | "zh") || i18n.defaultLanguage;
+  const lang = resolveLocale(params.lang) ?? i18n.defaultLanguage;
   const t = texts[lang];
 
   // 默认语言（zh）不显示前缀，其他语言显示前缀


### PR DESCRIPTION
Follow-up after #165 to finish the Cloudflare deployment path.\n\nChanges:\n- run the docs app on Cloudflare Workers\n- add production smoke checks for the Workers docs routes\n- harden Semifold Linux dependency installs and isolate Rust cache by runner platform\n- update README deployment notes\n\nValidation:\n- Cloudflare Workers build passed on c735629\n- prek passed on c735629\n- Semifold CI, including Linux arm64 and Release, passed on c735629

## Summary by Sourcery

Finalize Cloudflare Workers deployment for the docs site and add production monitoring and CI hardening.

New Features:
- Deploy the docs site via a Cloudflare Worker entrypoint with server rendering.
- Add a production smoke-check workflow that validates key Cloudflare Workers docs routes on pushes and on a schedule.

Enhancements:
- Introduce locale resolution helpers and 404 handling for invalid language prefixes across docs routes.
- Harden Linux dependency installation in CI with retries, timeouts, and platform-scoped Rust caching.
- Update docs and README to describe Cloudflare Workers as the primary docs deployment target and document deploy commands.

CI:
- Adjust Semifold CI matrix to use ubuntu-22.04 for arm builds and improve Rust cache keys to include the runner platform.

Documentation:
- Revise docs deployment README to reflect Cloudflare Workers as the production path and provide deploy/validation commands.