### PR TITLE
fix(docs): preserve locale in manual links

### DIFF
--- a/packages/docs/content/en/manual/features/authentication.mdx
+++ b/packages/docs/content/en/manual/features/authentication.mdx
@@ -19,7 +19,7 @@ DropOut uses the **Device Code Flow** for Microsoft authentication, featuring:
 
 ### Authentication Process
 
-The authentication chain consists of multiple steps. DropOut automatically handles these complex exchange processes, including interactions with Microsoft, Xbox Live, and Minecraft services. If you are interested in detailed API implementation, please refer to [Internal Implementation](/docs/development/implementation#1-authentication-system).
+The authentication chain consists of multiple steps. DropOut automatically handles these complex exchange processes, including interactions with Microsoft, Xbox Live, and Minecraft services. If you are interested in detailed API implementation, please refer to [Internal Implementation](/en/docs/development/implementation#1-authentication-system).
 
 ### Token Management
 
@@ -121,7 +121,7 @@ Steps to delete an account:
 
 ## API Reference
 
-For low-level implementation of authentication, OAuth 2.0 flow details, and related Tauri command interfaces, please refer to the development documentation: [Implementation Details: Authentication](/docs/development/implementation#1-authentication-system).
+For low-level implementation of authentication, OAuth 2.0 flow details, and related Tauri command interfaces, please refer to the development documentation: [Implementation Details: Authentication](/en/docs/development/implementation#1-authentication-system).
 
 ## Best Practices
 

--- a/packages/docs/content/en/manual/features/index.mdx
+++ b/packages/docs/content/en/manual/features/index.mdx
@@ -129,7 +129,7 @@ Modded versions (Fabric/Forge) automatically inherit from parent vanilla version
 ## Developer Features
 
 ### Config Editor
-Built-in [Monaco configuration editor](/docs/manual/features/config-editor) with:
+Built-in [Monaco configuration editor](/en/docs/manual/features/config-editor) with:
 - Local syntax highlighting without a CDN
 - JSON schema validation and diagnostics
 - Formatting, keyboard save, reset, and unsaved-change protection

--- a/packages/docs/content/en/manual/features/mod-loaders.mdx
+++ b/packages/docs/content/en/manual/features/mod-loaders.mdx
@@ -28,7 +28,7 @@ Fabric is a lightweight, modular modding toolchain focused on:
 
 ### How It Works
 
-DropOut integrates with the Fabric Meta API to automatically fetch compatible loader versions. In the background, it generates the version JSON, handles library dependencies, and utilizes the inheritance system to ensure perfect compatibility with vanilla Minecraft. Detailed JSON structure can be found in [Technical Details](/docs/development/implementation#fabric-integration).
+DropOut integrates with the Fabric Meta API to automatically fetch compatible loader versions. In the background, it generates the version JSON, handles library dependencies, and utilizes the inheritance system to ensure perfect compatibility with vanilla Minecraft. Detailed JSON structure can be found in [Technical Details](/en/docs/development/implementation#fabric-integration).
 
 ### Fabric Versions
 

--- a/packages/docs/content/en/manual/getting-started.mdx
+++ b/packages/docs/content/en/manual/getting-started.mdx
@@ -117,27 +117,27 @@ DropOut calculates the Java and file checks with the same backend rules used by 
 <Cards>
   <Card
     title="Features"
-    href="/docs/manual/features"
+    href="/en/docs/manual/features"
     description="Learn about all the features DropOut offers"
   />
   <Card
     title="Instances"
-    href="/docs/manual/features/instances"
+    href="/en/docs/manual/features/instances"
     description="Create isolated game environments"
   />
   <Card
     title="Mod Loaders"
-    href="/docs/manual/features/mod-loaders"
+    href="/en/docs/manual/features/mod-loaders"
     description="Install and manage Fabric and Forge"
   />
   <Card
     title="Alpha 7 release notes"
-    href="/docs/manual/releases/alpha-7"
+    href="/en/docs/manual/releases/alpha-7"
     description="Review the UX changes, upgrade notes, and known limitations"
   />
   <Card
     title="Troubleshooting"
-    href="/docs/manual/troubleshooting"
+    href="/en/docs/manual/troubleshooting"
     description="Common issues and solutions"
   />
 </Cards>
@@ -162,6 +162,6 @@ DropOut calculates the Java and file checks with the same backend rules used by 
 
 If you encounter issues:
 
-- Check the [Troubleshooting Guide](/docs/manual/troubleshooting)
+- Check the [Troubleshooting Guide](/en/docs/manual/troubleshooting)
 - Report bugs on [GitHub Issues](https://github.com/HydroRoll-Team/DropOut/issues)
 - Join our community discussions

--- a/packages/docs/content/en/manual/index.mdx
+++ b/packages/docs/content/en/manual/index.mdx
@@ -36,12 +36,12 @@ This launcher is built for players who value control, transparency, and long-ter
   />
   <Card 
     title="Architecture" 
-    href="/docs/development/architecture"
+    href="/en/docs/development/architecture"
     description="Learn about the technical design"
   />
   <Card 
     title="Development" 
-    href="/docs/development"
+    href="/en/docs/development"
     description="Build and contribute to DropOut"
   />
 </Cards>

--- a/packages/docs/content/en/manual/releases/alpha-7.mdx
+++ b/packages/docs/content/en/manual/releases/alpha-7.mdx
@@ -46,4 +46,4 @@ Development fixtures cover empty, ready, downloading, running, failed, migration
 - Launcher auto-update and the complete in-launcher mods manager are not finished.
 - Migration is a preview workflow until the Alpha 8 compatibility milestone is complete.
 
-Continue with the [launch workflow](/docs/manual/getting-started), [instance library](/docs/manual/features/instances), or [Monaco configuration editor](/docs/manual/features/config-editor).
+Continue with the [launch workflow](/en/docs/manual/getting-started), [instance library](/en/docs/manual/features/instances), or [Monaco configuration editor](/en/docs/manual/features/config-editor).

--- a/packages/docs/content/zh/manual/features/index.mdx
+++ b/packages/docs/content/zh/manual/features/index.mdx
@@ -129,7 +129,7 @@ DropOut 功能丰富，既适合休闲玩家也适合高级用户。本指南涵
 ## 开发者功能
 
 ### 配置编辑器
-内置 [Monaco 配置编辑器](/zh/docs/manual/features/config-editor)，具有：
+内置 [Monaco 配置编辑器](/docs/manual/features/config-editor)，具有：
 - 无需 CDN 的本地语法高亮
 - JSON Schema 校验与诊断
 - 格式化、键盘保存、重置和未保存更改保护

--- a/packages/docs/content/zh/manual/getting-started.mdx
+++ b/packages/docs/content/zh/manual/getting-started.mdx
@@ -115,19 +115,19 @@ DropOut 使用与真实启动命令相同的后端规则计算 Java 和文件状
 ## 下一步
 
 <Cards>
-  <Card title="功能特性" href="/zh/docs/manual/features" description="了解 DropOut 提供的所有功能" />
-  <Card title="实例管理" href="/zh/docs/manual/features/instances" description="创建隔离的游戏环境" />
+  <Card title="功能特性" href="/docs/manual/features" description="了解 DropOut 提供的所有功能" />
+  <Card title="实例管理" href="/docs/manual/features/instances" description="创建隔离的游戏环境" />
   <Card
     title="模组加载器"
-    href="/zh/docs/manual/features/mod-loaders"
+    href="/docs/manual/features/mod-loaders"
     description="安装和管理 Fabric 和 Forge"
   />
   <Card
     title="Alpha 7 发布说明"
-    href="/zh/docs/manual/releases/alpha-7"
+    href="/docs/manual/releases/alpha-7"
     description="查看 UX 变化、升级说明和已知限制"
   />
-  <Card title="故障排除" href="/zh/docs/manual/troubleshooting" description="常见问题和解决方案" />
+  <Card title="故障排除" href="/docs/manual/troubleshooting" description="常见问题和解决方案" />
 </Cards>
 
 ## 系统要求
@@ -150,6 +150,6 @@ DropOut 使用与真实启动命令相同的后端规则计算 Java 和文件状
 
 如果遇到问题：
 
-- 查看[故障排除指南](/zh/docs/manual/troubleshooting)
+- 查看[故障排除指南](/docs/manual/troubleshooting)
 - 在 [GitHub Issues](https://github.com/HydroRoll-Team/DropOut/issues) 上报告 bug
 - 加入我们的社区讨论

--- a/packages/docs/content/zh/manual/index.mdx
+++ b/packages/docs/content/zh/manual/index.mdx
@@ -36,12 +36,12 @@ DropOut 是一个使用 Tauri v2 构建的现代 Minecraft 启动器，专为重
   />
   <Card 
     title="架构设计" 
-    href="/zh/docs/development/architecture"
+    href="/docs/development/architecture"
     description="了解技术设计"
   />
   <Card 
     title="开发指南" 
-    href="/zh/docs/development"
+    href="/docs/development"
     description="构建和贡献代码"
   />
 </Cards>

--- a/packages/docs/content/zh/manual/releases/alpha-7.mdx
+++ b/packages/docs/content/zh/manual/releases/alpha-7.mdx
@@ -46,4 +46,4 @@ Alpha 7 将 DropOut 的核心启动器界面整理为可检查的日常工作流
 - 启动器自动更新和完整的内置模组管理器尚未完成。
 - Alpha 8 兼容性里程碑完成前，迁移仍属于预览工作流。
 
-继续阅读[启动流程](/zh/docs/manual/getting-started)、[实例库](/zh/docs/manual/features/instances)或 [Monaco 配置编辑器](/zh/docs/manual/features/config-editor)。
+继续阅读[启动流程](/docs/manual/getting-started)、[实例库](/docs/manual/features/instances)或 [Monaco 配置编辑器](/docs/manual/features/config-editor)。


### PR DESCRIPTION
## Summary

- keep English manual navigation on the canonical `/en/docs/...` routes
- keep Chinese manual navigation on the default `/docs/...` routes
- fix existing authentication and mod-loader implementation links that switched English readers to Chinese

## Root cause

The docs site hides its default Chinese locale, so `/docs/...` is Chinese and English must retain the `/en` prefix.

## Validation

- `pnpm -C packages/docs types:check`
- `pnpm docs:build`
- local content smoke verifies English and Chinese pages, release notes, and target hrefs
- `pnpm exec prek run --all-files`
- no English `/docs/...` or Chinese `/zh/docs/...` content links remain
- `git diff --check`

## Summary by Sourcery

Align documentation links with locale-specific routes for English and Chinese manuals.

Documentation:
- Update English manual links to consistently use the canonical /en/docs/... routes.
- Update Chinese manual links to consistently use the default /docs/... routes and avoid /zh/docs/... paths.