### PR TITLE
feat(linux): add Alpine musl release build

### DIFF
--- a/.changes/alpha9-linux-musl.md
+++ b/.changes/alpha9-linux-musl.md
@@ -1,0 +1,6 @@
+---
+"dropout": "patch:feat"
+"@dropout/docs": "patch:feat"
+---
+
+Add a reproducible Alpine musl archive that is checksum-verified and smoke-tested from the packaged release in a clean runtime image.

--- a/.changes/alpha9-linux-musl.md
+++ b/.changes/alpha9-linux-musl.md
@@ -3,4 +3,4 @@
 "@dropout/docs": "patch:feat"
 ---
 
-Add a reproducible Alpine musl archive that is checksum-verified and smoke-tested from the packaged release in a clean runtime image.
+Add signed build provenance for desktop artifacts and a reproducible Alpine musl archive that is checksum-verified and smoke-tested from the packaged release in a clean runtime image.

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+.git
+.codegraph
+.pnpm-store
+Cargo.lock
+artifacts
+node_modules
+packages/*/dist
+packages/*/node_modules
+packages/ui/playwright-report
+packages/ui/test-results
+target

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,7 +1,6 @@
 .git
 .codegraph
 .pnpm-store
-Cargo.lock
 artifacts
 node_modules
 packages/*/dist

--- a/.github/docker/linux-musl.Dockerfile
+++ b/.github/docker/linux-musl.Dockerfile
@@ -1,0 +1,43 @@
+# syntax=docker/dockerfile:1.7
+
+ARG RUST_IMAGE=rust:1.97-alpine3.22@sha256:df4efa4e0cdfb5245fa06e3f431387b2bcc96782ce5681b7fb6b0297d745bc29
+FROM ${RUST_IMAGE} AS build
+
+RUN apk add --no-cache \
+      binutils \
+      build-base \
+      dbus-x11 \
+      file \
+      git \
+      gtk+3.0-dev \
+      libayatana-appindicator-dev \
+      librsvg-dev \
+      nodejs \
+      npm \
+      openssl-dev \
+      pkgconf \
+      pnpm \
+      tar \
+      webkit2gtk-4.1-dev \
+      xvfb-run
+
+ENV CI=true \
+    CARGO_BUILD_JOBS=1 \
+    PATH=/usr/local/cargo/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+
+WORKDIR /workspace
+COPY . .
+RUN mkdir -p /workspace/.cargo \
+    && cp .github/docker/linux-musl.cargo.toml /workspace/.cargo/config.toml
+
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,target=/workspace/target \
+    --mount=type=cache,target=/root/.local/share/pnpm/store \
+    pnpm install --frozen-lockfile \
+    && pnpm -C packages/ui --lockfile-dir /workspace install --frozen-lockfile \
+    && pnpm exec tauri build --target x86_64-unknown-linux-musl --no-bundle \
+    && scripts/verify-linux-musl.sh target/x86_64-unknown-linux-musl/release/dropout \
+    && scripts/package-linux-musl.sh target/x86_64-unknown-linux-musl/release/dropout artifacts
+
+FROM scratch AS artifact
+COPY --from=build /workspace/artifacts/ /

--- a/.github/docker/linux-musl.Dockerfile
+++ b/.github/docker/linux-musl.Dockerfile
@@ -1,6 +1,7 @@
 # syntax=docker/dockerfile:1.7
 
 ARG RUST_IMAGE=rust:1.97-alpine3.22@sha256:df4efa4e0cdfb5245fa06e3f431387b2bcc96782ce5681b7fb6b0297d745bc29
+ARG ALPINE_RUNTIME_IMAGE=alpine:3.22@sha256:14358309a308569c32bdc37e2e0e9694be33a9d99e68afb0f5ff33cc1f695dce
 FROM ${RUST_IMAGE} AS build
 
 RUN apk add --no-cache \
@@ -36,8 +37,29 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
     pnpm install --frozen-lockfile \
     && pnpm -C packages/ui --lockfile-dir /workspace install --frozen-lockfile \
     && pnpm exec tauri build --target x86_64-unknown-linux-musl --no-bundle \
-    && scripts/verify-linux-musl.sh target/x86_64-unknown-linux-musl/release/dropout \
     && scripts/package-linux-musl.sh target/x86_64-unknown-linux-musl/release/dropout artifacts
 
+FROM ${ALPINE_RUNTIME_IMAGE} AS verify-runtime
+
+RUN apk add --no-cache \
+      ca-certificates \
+      gtk+3.0 \
+      libayatana-appindicator \
+      librsvg \
+      openssl \
+      webkit2gtk-4.1 \
+    && apk add --no-cache --virtual .dropout-smoke-deps \
+      binutils \
+      dbus-x11 \
+      file \
+      musl-utils \
+      xvfb-run
+
+COPY --from=build /workspace/artifacts/ /artifacts/
+COPY scripts/verify-linux-musl.sh scripts/verify-linux-musl-package.sh /usr/local/bin/
+
+RUN chmod +x /usr/local/bin/verify-linux-musl.sh /usr/local/bin/verify-linux-musl-package.sh \
+    && verify-linux-musl-package.sh /artifacts
+
 FROM scratch AS artifact
-COPY --from=build /workspace/artifacts/ /
+COPY --from=verify-runtime /artifacts/ /

--- a/.github/docker/linux-musl.cargo.toml
+++ b/.github/docker/linux-musl.cargo.toml
@@ -1,5 +1,9 @@
 # Alpine/musl CI runs in a constrained container. These package-specific
 # overrides leave every other release target on the workspace's opt-level 3.
+[env]
+TS_RS_EXPORT_DIR = { value = "./packages/ui/src/types/bindings", relative = true }
+TS_RS_LARGE_INT = "number"
+
 [target.x86_64-unknown-linux-musl]
 rustflags = ["-C", "target-feature=-crt-static"]
 

--- a/.github/docker/linux-musl.cargo.toml
+++ b/.github/docker/linux-musl.cargo.toml
@@ -1,0 +1,11 @@
+# Alpine/musl CI runs in a constrained container. These package-specific
+# overrides leave every other release target on the workspace's opt-level 3.
+[target.x86_64-unknown-linux-musl]
+rustflags = ["-C", "target-feature=-crt-static"]
+
+[profile.release.package.gtk]
+opt-level = 1
+
+[profile.release.package.dropout]
+opt-level = 1
+codegen-units = 16

--- a/.github/workflows/semifold-ci.yaml
+++ b/.github/workflows/semifold-ci.yaml
@@ -12,6 +12,7 @@ env:
 
 permissions:
   id-token: write
+  attestations: write
   contents: write
   pull-requests: write
 
@@ -191,8 +192,10 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Verify musl release contract
-        run: scripts/test-linux-musl-release.sh
+      - name: Verify distribution release contracts
+        run: |
+          scripts/test-linux-musl-release.sh
+          scripts/test-release-provenance.sh
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -244,6 +247,10 @@ jobs:
           merge-multiple: true
       - name: List artifacts
         run: ls -R artifacts/
+      - name: Attest release artifacts
+        uses: actions/attest@v4
+        with:
+          subject-path: artifacts/**/*
       - name: Semifold CI
         run: semifold ci
         env:

--- a/.github/workflows/semifold-ci.yaml
+++ b/.github/workflows/semifold-ci.yaml
@@ -184,11 +184,39 @@ jobs:
             target/${{ matrix.target }}/release/bundle/macos/*.app.tar.gz
           retention-days: 1
 
+  build-linux-musl:
+    name: Build on Linux x86_64 (Musl)
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and verify Alpine musl artifact
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: .github/docker/linux-musl.Dockerfile
+          target: artifact
+          outputs: type=local,dest=artifacts/linux-musl
+          cache-from: type=gha,scope=linux-musl
+          cache-to: type=gha,mode=max,scope=linux-musl
+
+      - name: Upload musl artifact
+        uses: actions/upload-artifact@v6
+        with:
+          name: linux-x86_64-unknown-linux-musl-artifacts
+          path: artifacts/linux-musl/*
+          if-no-files-found: error
+          retention-days: 1
+
   release:
     name: Release
     if: github.event_name == 'push'
     runs-on: ubuntu-latest
-    needs: [build-tauri]
+    needs: [build-tauri, build-linux-musl]
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/.github/workflows/semifold-ci.yaml
+++ b/.github/workflows/semifold-ci.yaml
@@ -191,6 +191,9 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - name: Verify musl release contract
+        run: scripts/test-linux-musl-release.sh
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 

--- a/packages/docs/content/en/manual/getting-started.mdx
+++ b/packages/docs/content/en/manual/getting-started.mdx
@@ -23,6 +23,14 @@ Download the latest prerelease for your platform from the [HydroRoll Team releas
 | Windows x86_64           | NSIS `.exe` installer  |
 | Windows ARM64            | NSIS `.exe` installer  |
 
+Every supported desktop asset has signed GitHub build provenance. After downloading an asset, verify that it was produced by this repository's release workflow:
+
+```bash
+gh attestation verify ./downloaded-asset -R HydroRoll-Team/DropOut
+```
+
+Replace `./downloaded-asset` with the installer or archive path. A successful result verifies the artifact digest and its short-lived Sigstore signature before installation.
+
 ### Linux Installation
 
 #### Using .deb Package

--- a/packages/docs/content/en/manual/getting-started.mdx
+++ b/packages/docs/content/en/manual/getting-started.mdx
@@ -46,12 +46,13 @@ The musl archive targets Alpine Linux 3.22 on x86_64. Install its native WebKitG
 
 ```bash
 sudo apk add ca-certificates gtk+3.0 libayatana-appindicator librsvg openssl webkit2gtk-4.1
+sha256sum -c Dropout_*-musl.tar.gz.sha256
 tar -xzf Dropout_*-musl.tar.gz
 cd Dropout_*-musl
 ./dropout
 ```
 
-The musl archive is dynamically linked against Alpine packages. Use the AppImage or `.deb` package on glibc distributions such as Ubuntu, Debian, Fedora, or Arch Linux.
+The checksum command verifies the packaged archive before extraction. The musl archive is dynamically linked against Alpine packages. Use the AppImage or `.deb` package on glibc distributions such as Ubuntu, Debian, Fedora, or Arch Linux.
 
 ### macOS Installation
 

--- a/packages/docs/content/en/manual/getting-started.mdx
+++ b/packages/docs/content/en/manual/getting-started.mdx
@@ -13,14 +13,15 @@ DropOut is a modern, reproducible, and developer-grade Minecraft launcher built 
 
 Download the latest prerelease for your platform from the [HydroRoll Team releases](https://github.com/HydroRoll-Team/DropOut/releases) page. Alpha builds are intended for testing, so export important instances before upgrading.
 
-| Platform       | Release asset        |
-| -------------- | -------------------- |
-| Linux x86_64   | `.deb`, `.AppImage`  |
-| Linux ARM64    | `.deb`, `.AppImage`  |
-| macOS x86_64   | `.dmg`               |
-| macOS ARM64    | `.dmg`               |
-| Windows x86_64 | NSIS `.exe` installer |
-| Windows ARM64  | NSIS `.exe` installer |
+| Platform                 | Release asset          |
+| ------------------------ | ---------------------- |
+| Linux x86_64 (glibc)     | `.deb`, `.AppImage`    |
+| Linux ARM64 (glibc)      | `.deb`, `.AppImage`    |
+| Alpine Linux x86_64      | `-musl.tar.gz` archive |
+| macOS x86_64             | `.dmg`                 |
+| macOS ARM64              | `.dmg`                 |
+| Windows x86_64           | NSIS `.exe` installer  |
+| Windows ARM64            | NSIS `.exe` installer  |
 
 ### Linux Installation
 
@@ -38,6 +39,19 @@ sudo apt-get install -f
 chmod +x Dropout_*.AppImage
 ./Dropout_*.AppImage
 ```
+
+#### Using the Alpine Linux musl archive
+
+The musl archive targets Alpine Linux 3.22 on x86_64. Install its native WebKitGTK runtime dependencies, extract it, and launch the included binary:
+
+```bash
+sudo apk add ca-certificates gtk+3.0 libayatana-appindicator librsvg openssl webkit2gtk-4.1
+tar -xzf Dropout_*-musl.tar.gz
+cd Dropout_*-musl
+./dropout
+```
+
+The musl archive is dynamically linked against Alpine packages. Use the AppImage or `.deb` package on glibc distributions such as Ubuntu, Debian, Fedora, or Arch Linux.
 
 ### macOS Installation
 
@@ -146,7 +160,7 @@ DropOut calculates the Java and file checks with the same backend rules used by 
 
 ### Minimum Requirements
 
-- **OS**: Windows 10+, macOS 11+, or Linux (Debian-based)
+- **OS**: Windows 10+, macOS 11+, glibc Linux, or Alpine Linux 3.22 x86_64
 - **RAM**: 4GB (8GB recommended for modded Minecraft)
 - **Storage**: 2GB for launcher + game files
 - **Java**: Auto-installed by DropOut if not found

--- a/packages/docs/content/zh/manual/getting-started.mdx
+++ b/packages/docs/content/zh/manual/getting-started.mdx
@@ -46,12 +46,13 @@ musl 压缩包面向 Alpine Linux 3.22 x86_64 系统。安装原生 WebKitGTK �
 
 ```bash
 sudo apk add ca-certificates gtk+3.0 libayatana-appindicator librsvg openssl webkit2gtk-4.1
+sha256sum -c Dropout_*-musl.tar.gz.sha256
 tar -xzf Dropout_*-musl.tar.gz
 cd Dropout_*-musl
 ./dropout
 ```
 
-musl 压缩包会动态链接 Alpine 软件包。在 Ubuntu、Debian、Fedora 或 Arch Linux 等 glibc 发行版上，请使用 AppImage 或 `.deb` 包。
+校验命令会在解压前验证发布包的完整性。musl 压缩包会动态链接 Alpine 软件包。在 Ubuntu、Debian、Fedora 或 Arch Linux 等 glibc 发行版上，请使用 AppImage 或 `.deb` 包。
 
 ### macOS 安装
 

--- a/packages/docs/content/zh/manual/getting-started.mdx
+++ b/packages/docs/content/zh/manual/getting-started.mdx
@@ -23,6 +23,14 @@ DropOut 是一个使用 Tauri v2 构建的现代化、可复现、开发者级�
 | Windows x86_64           | NSIS `.exe` 安装程序   |
 | Windows ARM64            | NSIS `.exe` 安装程序   |
 
+所有受支持的桌面发布产物都会生成带签名的 GitHub 构建来源证明。下载后，可验证该文件是否确实由本仓库的发布工作流生成：
+
+```bash
+gh attestation verify ./downloaded-asset -R HydroRoll-Team/DropOut
+```
+
+请将 `./downloaded-asset` 替换为安装包或压缩包路径。验证成功代表产物摘要和短期 Sigstore 签名均已通过，然后再继续安装。
+
 ### Linux 安装
 
 #### 使用 .deb 包

--- a/packages/docs/content/zh/manual/getting-started.mdx
+++ b/packages/docs/content/zh/manual/getting-started.mdx
@@ -13,14 +13,15 @@ DropOut 是一个使用 Tauri v2 构建的现代化、可复现、开发者级�
 
 从 [HydroRoll Team 发布页面](https://github.com/HydroRoll-Team/DropOut/releases)下载适合你平台的最新预发布版本。Alpha 版本用于测试，升级前请先导出重要实例。
 
-| 平台           | 发布产物              |
-| -------------- | --------------------- |
-| Linux x86_64   | `.deb`、`.AppImage`   |
-| Linux ARM64    | `.deb`、`.AppImage`   |
-| macOS x86_64   | `.dmg`                |
-| macOS ARM64    | `.dmg`                |
-| Windows x86_64 | NSIS `.exe` 安装程序  |
-| Windows ARM64  | NSIS `.exe` 安装程序  |
+| 平台                     | 发布产物               |
+| ------------------------ | ---------------------- |
+| Linux x86_64（glibc）    | `.deb`、`.AppImage`    |
+| Linux ARM64（glibc）     | `.deb`、`.AppImage`    |
+| Alpine Linux x86_64      | `-musl.tar.gz` 压缩包  |
+| macOS x86_64             | `.dmg`                 |
+| macOS ARM64              | `.dmg`                 |
+| Windows x86_64           | NSIS `.exe` 安装程序   |
+| Windows ARM64            | NSIS `.exe` 安装程序   |
 
 ### Linux 安装
 
@@ -38,6 +39,19 @@ sudo apt-get install -f
 chmod +x Dropout_*.AppImage
 ./Dropout_*.AppImage
 ```
+
+#### 使用 Alpine Linux musl 压缩包
+
+musl 压缩包面向 Alpine Linux 3.22 x86_64 系统。安装原生 WebKitGTK 运行依赖后，解压并启动其中的二进制文件：
+
+```bash
+sudo apk add ca-certificates gtk+3.0 libayatana-appindicator librsvg openssl webkit2gtk-4.1
+tar -xzf Dropout_*-musl.tar.gz
+cd Dropout_*-musl
+./dropout
+```
+
+musl 压缩包会动态链接 Alpine 软件包。在 Ubuntu、Debian、Fedora 或 Arch Linux 等 glibc 发行版上，请使用 AppImage 或 `.deb` 包。
 
 ### macOS 安装
 
@@ -134,7 +148,7 @@ DropOut 使用与真实启动命令相同的后端规则计算 Java 和文件状
 
 ### 最低要求
 
-- **操作系统**: Windows 10+、macOS 11+ 或 Linux（基于 Debian）
+- **操作系统**: Windows 10+、macOS 11+、glibc Linux，或 Alpine Linux 3.22 x86_64
 - **内存**: 4GB（推荐 8GB 用于模组 Minecraft）
 - **存储**: 启动器 + 游戏文件需要 2GB
 - **Java**: 如果找不到，DropOut 会自动安装

--- a/packaging/linux-musl/README.md
+++ b/packaging/linux-musl/README.md
@@ -8,6 +8,12 @@ Install the runtime libraries:
 sudo apk add ca-certificates gtk+3.0 libayatana-appindicator librsvg openssl webkit2gtk-4.1
 ```
 
+Verify the adjacent checksum before extracting the archive:
+
+```sh
+sha256sum -c Dropout_*-musl.tar.gz.sha256
+```
+
 Then start the launcher from the extracted directory:
 
 ```sh

--- a/packaging/linux-musl/README.md
+++ b/packaging/linux-musl/README.md
@@ -1,0 +1,19 @@
+# DropOut for Alpine Linux
+
+This archive contains the native x86_64 musl build of DropOut for Alpine Linux 3.22.
+
+Install the runtime libraries:
+
+```sh
+sudo apk add ca-certificates gtk+3.0 libayatana-appindicator librsvg openssl webkit2gtk-4.1
+```
+
+Then start the launcher from the extracted directory:
+
+```sh
+./dropout
+```
+
+To integrate DropOut with your desktop environment, copy `dropout.desktop` to `~/.local/share/applications/`, copy `dropout.png` to `~/.local/share/icons/`, and adjust the `Exec` and `Icon` paths to their absolute locations.
+
+This is a dynamically linked Alpine build. It is not a portable replacement for the glibc AppImage or Debian package.

--- a/packaging/linux-musl/dropout.desktop
+++ b/packaging/linux-musl/dropout.desktop
@@ -1,0 +1,8 @@
+[Desktop Entry]
+Type=Application
+Name=DropOut
+Comment=Minecraft game launcher
+Exec=dropout
+Icon=dropout
+Terminal=false
+Categories=Game;

--- a/scripts/package-linux-musl.sh
+++ b/scripts/package-linux-musl.sh
@@ -3,13 +3,20 @@ set -eu
 
 binary_path="${1:-target/x86_64-unknown-linux-musl/release/dropout}"
 output_dir="${2:-artifacts}"
+script_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+repo_root=$(CDPATH= cd -- "$script_dir/.." && pwd)
 
 if [ ! -x "$binary_path" ]; then
   echo "musl binary is missing or not executable: $binary_path" >&2
   exit 1
 fi
 
-version=$(node -p "require('./src-tauri/tauri.conf.json').version")
+tauri_conf="$repo_root/src-tauri/tauri.conf.json"
+if ! command -v node >/dev/null 2>&1; then
+  echo "node is required to read $tauri_conf" >&2
+  exit 1
+fi
+version=$(node -p "require(process.argv[1]).version" "$tauri_conf")
 package_name="Dropout_${version}_linux_x86_64-musl"
 archive_path="$output_dir/${package_name}.tar.gz"
 staging_root=$(mktemp -d)
@@ -23,9 +30,9 @@ package_root="$staging_root/$package_name"
 mkdir -p "$package_root" "$output_dir"
 
 install -m 755 "$binary_path" "$package_root/dropout"
-install -m 644 packaging/linux-musl/README.md "$package_root/README.md"
-install -m 644 packaging/linux-musl/dropout.desktop "$package_root/dropout.desktop"
-install -m 644 src-tauri/icons/128x128.png "$package_root/dropout.png"
+install -m 644 "$repo_root/packaging/linux-musl/README.md" "$package_root/README.md"
+install -m 644 "$repo_root/packaging/linux-musl/dropout.desktop" "$package_root/dropout.desktop"
+install -m 644 "$repo_root/src-tauri/icons/128x128.png" "$package_root/dropout.png"
 
 tar \
   --sort=name \
@@ -37,5 +44,15 @@ tar \
   -czf "$archive_path" \
   "$package_name"
 
-(cd "$output_dir" && sha256sum "${package_name}.tar.gz" >"${package_name}.tar.gz.sha256")
+(
+  cd "$output_dir"
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "${package_name}.tar.gz" >"${package_name}.tar.gz.sha256"
+  elif command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 "${package_name}.tar.gz" >"${package_name}.tar.gz.sha256"
+  else
+    echo "sha256sum or shasum is required to checksum the musl archive" >&2
+    exit 1
+  fi
+)
 echo "Packaged $archive_path"

--- a/scripts/package-linux-musl.sh
+++ b/scripts/package-linux-musl.sh
@@ -1,0 +1,41 @@
+#!/bin/sh
+set -eu
+
+binary_path="${1:-target/x86_64-unknown-linux-musl/release/dropout}"
+output_dir="${2:-artifacts}"
+
+if [ ! -x "$binary_path" ]; then
+  echo "musl binary is missing or not executable: $binary_path" >&2
+  exit 1
+fi
+
+version=$(node -p "require('./src-tauri/tauri.conf.json').version")
+package_name="Dropout_${version}_linux_x86_64-musl"
+archive_path="$output_dir/${package_name}.tar.gz"
+staging_root=$(mktemp -d)
+
+cleanup() {
+  rm -rf "$staging_root"
+}
+trap cleanup EXIT HUP INT TERM
+
+package_root="$staging_root/$package_name"
+mkdir -p "$package_root" "$output_dir"
+
+install -m 755 "$binary_path" "$package_root/dropout"
+install -m 644 packaging/linux-musl/README.md "$package_root/README.md"
+install -m 644 packaging/linux-musl/dropout.desktop "$package_root/dropout.desktop"
+install -m 644 src-tauri/icons/128x128.png "$package_root/dropout.png"
+
+tar \
+  --sort=name \
+  --owner=0 \
+  --group=0 \
+  --numeric-owner \
+  --mtime="@${SOURCE_DATE_EPOCH:-0}" \
+  -C "$staging_root" \
+  -czf "$archive_path" \
+  "$package_name"
+
+(cd "$output_dir" && sha256sum "${package_name}.tar.gz" >"${package_name}.tar.gz.sha256")
+echo "Packaged $archive_path"

--- a/scripts/test-linux-musl-release.sh
+++ b/scripts/test-linux-musl-release.sh
@@ -46,4 +46,45 @@ if "$repo_root/scripts/verify-linux-musl-package.sh" "$artifact_dir" archive-onl
   exit 1
 fi
 
+mock_bin="$fixture_root/mock-bin"
+mkdir -p "$mock_bin"
+printf '#!/bin/sh\nprintf "ELF 64-bit fixture\\n"\nexit 7\n' >"$mock_bin/file"
+printf '#!/bin/sh\nprintf "interpreter /lib/ld-musl-x86_64.so.1\\n"\n' >"$mock_bin/readelf"
+printf '#!/bin/sh\nprintf "libfixture.so => /lib/libfixture.so\\n"\n' >"$mock_bin/ldd"
+printf '#!/bin/sh\nexit 124\n' >"$mock_bin/timeout"
+chmod +x "$mock_bin/file" "$mock_bin/readelf" "$mock_bin/ldd" "$mock_bin/timeout"
+
+fake_binary="$fixture_root/fake-dropout"
+printf '#!/bin/sh\nexit 0\n' >"$fake_binary"
+chmod +x "$fake_binary"
+if PATH="$mock_bin:$PATH" "$repo_root/scripts/verify-linux-musl.sh" "$fake_binary" >/dev/null 2>&1; then
+  echo "musl verification must preserve failed inspection commands" >&2
+  exit 1
+fi
+
+printf '%s\n' \
+  '#!/bin/sh' \
+  'archive_path=' \
+  'while [ "$#" -gt 0 ]; do' \
+  '  if [ "$1" = "-czf" ]; then' \
+  '    shift' \
+  '    archive_path=$1' \
+  '  fi' \
+  '  shift' \
+  'done' \
+  '[ -n "$archive_path" ]' \
+  ': >"$archive_path"' >"$mock_bin/tar"
+printf '#!/bin/sh\nprintf "%%064d  %%s\\n" 0 "$1"\n' >"$mock_bin/sha256sum"
+chmod +x "$mock_bin/tar" "$mock_bin/sha256sum"
+
+portable_artifacts="$fixture_root/portable-artifacts"
+if ! (cd "$fixture_root" && PATH="$mock_bin:$PATH" "$repo_root/scripts/package-linux-musl.sh" "$fake_binary" "$portable_artifacts"); then
+  echo "musl packaging must resolve repository assets outside the checkout directory" >&2
+  exit 1
+fi
+set -- "$portable_artifacts"/Dropout_*_linux_x86_64-musl.tar.gz
+test "$#" -eq 1
+test -f "$1"
+test -f "$1.sha256"
+
 echo "musl release contract passed"

--- a/scripts/test-linux-musl-release.sh
+++ b/scripts/test-linux-musl-release.sh
@@ -1,0 +1,49 @@
+#!/bin/sh
+set -eu
+
+repo_root=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+dockerfile="$repo_root/.github/docker/linux-musl.Dockerfile"
+
+if grep -qx 'Cargo.lock' "$repo_root/.dockerignore"; then
+  echo "Cargo.lock must be included in reproducible musl builds" >&2
+  exit 1
+fi
+
+grep -q 'AS verify-runtime' "$dockerfile"
+grep -q 'verify-linux-musl-package.sh /artifacts' "$dockerfile"
+grep -q 'COPY --from=verify-runtime /artifacts/ /' "$dockerfile"
+
+fixture_root=$(mktemp -d)
+cleanup() {
+  rm -rf "$fixture_root"
+}
+trap cleanup EXIT HUP INT TERM
+
+package_name='Dropout_0.0.0_linux_x86_64-musl'
+package_root="$fixture_root/$package_name"
+artifact_dir="$fixture_root/artifacts"
+mkdir -p "$package_root" "$artifact_dir"
+
+printf '#!/bin/sh\nexit 0\n' >"$package_root/dropout"
+chmod +x "$package_root/dropout"
+printf 'fixture readme\n' >"$package_root/README.md"
+printf '[Desktop Entry]\nName=DropOut\n' >"$package_root/dropout.desktop"
+printf 'fixture icon\n' >"$package_root/dropout.png"
+
+archive="$artifact_dir/$package_name.tar.gz"
+tar -czf "$archive" -C "$fixture_root" "$package_name"
+if command -v sha256sum >/dev/null 2>&1; then
+  (cd "$artifact_dir" && sha256sum "$package_name.tar.gz" >"$package_name.tar.gz.sha256")
+else
+  (cd "$artifact_dir" && shasum -a 256 "$package_name.tar.gz" >"$package_name.tar.gz.sha256")
+fi
+
+"$repo_root/scripts/verify-linux-musl-package.sh" "$artifact_dir" archive-only
+
+printf 'corrupt\n' >>"$archive"
+if "$repo_root/scripts/verify-linux-musl-package.sh" "$artifact_dir" archive-only >/dev/null 2>&1; then
+  echo "corrupted musl archives must fail verification" >&2
+  exit 1
+fi
+
+echo "musl release contract passed"

--- a/scripts/test-linux-musl-release.sh
+++ b/scripts/test-linux-musl-release.sh
@@ -3,6 +3,7 @@ set -eu
 
 repo_root=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
 dockerfile="$repo_root/.github/docker/linux-musl.Dockerfile"
+musl_cargo_config="$repo_root/.github/docker/linux-musl.cargo.toml"
 
 if grep -qx 'Cargo.lock' "$repo_root/.dockerignore"; then
   echo "Cargo.lock must be included in reproducible musl builds" >&2
@@ -12,6 +13,8 @@ fi
 grep -q 'AS verify-runtime' "$dockerfile"
 grep -q 'verify-linux-musl-package.sh /artifacts' "$dockerfile"
 grep -q 'COPY --from=verify-runtime /artifacts/ /' "$dockerfile"
+grep -q '^TS_RS_EXPORT_DIR = ' "$musl_cargo_config"
+grep -q '^TS_RS_LARGE_INT = "number"$' "$musl_cargo_config"
 
 fixture_root=$(mktemp -d)
 cleanup() {
@@ -43,6 +46,27 @@ fi
 printf 'corrupt\n' >>"$archive"
 if "$repo_root/scripts/verify-linux-musl-package.sh" "$artifact_dir" archive-only >/dev/null 2>&1; then
   echo "corrupted musl archives must fail verification" >&2
+  exit 1
+fi
+
+symlink_fixture="$fixture_root/symlink-fixture"
+symlink_package_root="$symlink_fixture/$package_name"
+symlink_artifacts="$symlink_fixture/artifacts"
+mkdir -p "$symlink_package_root" "$symlink_artifacts"
+printf '#!/bin/sh\nexit 0\n' >"$symlink_package_root/payload"
+chmod +x "$symlink_package_root/payload"
+ln -s payload "$symlink_package_root/dropout"
+printf 'fixture readme\n' >"$symlink_package_root/README.md"
+printf '[Desktop Entry]\nName=DropOut\n' >"$symlink_package_root/dropout.desktop"
+printf 'fixture icon\n' >"$symlink_package_root/dropout.png"
+tar -czf "$symlink_artifacts/$package_name.tar.gz" -C "$symlink_fixture" "$package_name"
+if command -v sha256sum >/dev/null 2>&1; then
+  (cd "$symlink_artifacts" && sha256sum "$package_name.tar.gz" >"$package_name.tar.gz.sha256")
+else
+  (cd "$symlink_artifacts" && shasum -a 256 "$package_name.tar.gz" >"$package_name.tar.gz.sha256")
+fi
+if "$repo_root/scripts/verify-linux-musl-package.sh" "$symlink_artifacts" archive-only >/dev/null 2>&1; then
+  echo "musl archives containing symlinks must fail verification" >&2
   exit 1
 fi
 

--- a/scripts/test-release-provenance.sh
+++ b/scripts/test-release-provenance.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+set -eu
+
+repo_root=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+workflow="$repo_root/.github/workflows/semifold-ci.yaml"
+
+grep -q '^  attestations: write$' "$workflow"
+grep -q '^        uses: actions/attest@v4$' "$workflow"
+grep -q '^          subject-path: artifacts/\*\*/\*$' "$workflow"
+
+for guide in \
+  "$repo_root/packages/docs/content/en/manual/getting-started.mdx" \
+  "$repo_root/packages/docs/content/zh/manual/getting-started.mdx"
+do
+  grep -q 'gh attestation verify' "$guide"
+  grep -q -- '-R HydroRoll-Team/DropOut' "$guide"
+done
+
+echo "release provenance contract passed"

--- a/scripts/verify-linux-musl-package.sh
+++ b/scripts/verify-linux-musl-package.sh
@@ -32,8 +32,28 @@ else
   echo "$archive_name: OK"
 fi
 
-if tar -tzf "$archive" | grep -Eq '(^/|(^|/)\.\.(/|$))'; then
+if ! archive_entries=$(tar -tzf "$archive"); then
+  echo "musl archive cannot be listed" >&2
+  exit 1
+fi
+if printf '%s\n' "$archive_entries" | grep -Eq '(^/|(^|/)\.\.(/|$))'; then
   echo "musl archive contains an unsafe path" >&2
+  exit 1
+fi
+if ! archive_listing=$(tar -tvzf "$archive"); then
+  echo "musl archive metadata cannot be inspected" >&2
+  exit 1
+fi
+if printf '%s\n' "$archive_listing" | awk '
+  {
+    entry_type = substr($1, 1, 1)
+    if (entry_type != "-" && entry_type != "d") {
+      unsafe = 1
+    }
+  }
+  END { exit unsafe ? 0 : 1 }
+'; then
+  echo "musl archive contains a link or special file" >&2
   exit 1
 fi
 
@@ -44,6 +64,10 @@ cleanup() {
 trap cleanup EXIT HUP INT TERM
 
 tar -xzf "$archive" -C "$staging_root"
+if [ -n "$(find "$staging_root" -type l -print -quit)" ]; then
+  echo "musl archive extracted a symbolic link" >&2
+  exit 1
+fi
 set -- "$staging_root"/Dropout_*_linux_x86_64-musl
 if [ "$#" -ne 1 ] || [ ! -d "$1" ]; then
   echo "musl archive must contain exactly one package directory" >&2

--- a/scripts/verify-linux-musl-package.sh
+++ b/scripts/verify-linux-musl-package.sh
@@ -1,0 +1,77 @@
+#!/bin/sh
+set -eu
+
+artifact_dir="${1:-artifacts}"
+mode="${2:-full}"
+
+set -- "$artifact_dir"/Dropout_*_linux_x86_64-musl.tar.gz
+if [ "$#" -ne 1 ] || [ ! -f "$1" ]; then
+  echo "expected exactly one musl archive in $artifact_dir" >&2
+  exit 1
+fi
+
+archive=$1
+checksum="$archive.sha256"
+if [ ! -f "$checksum" ]; then
+  echo "musl checksum is missing: $checksum" >&2
+  exit 1
+fi
+
+archive_dir=$(CDPATH= cd -- "$(dirname -- "$archive")" && pwd)
+archive_name=$(basename -- "$archive")
+checksum_name=$(basename -- "$checksum")
+if command -v sha256sum >/dev/null 2>&1; then
+  (cd "$archive_dir" && sha256sum -c "$checksum_name")
+else
+  expected=$(awk 'NR == 1 { print $1 }' "$checksum")
+  actual=$(shasum -a 256 "$archive" | awk '{ print $1 }')
+  if [ -z "$expected" ] || [ "$actual" != "$expected" ]; then
+    echo "$archive_name: checksum mismatch" >&2
+    exit 1
+  fi
+  echo "$archive_name: OK"
+fi
+
+if tar -tzf "$archive" | grep -Eq '(^/|(^|/)\.\.(/|$))'; then
+  echo "musl archive contains an unsafe path" >&2
+  exit 1
+fi
+
+staging_root=$(mktemp -d)
+cleanup() {
+  rm -rf "$staging_root"
+}
+trap cleanup EXIT HUP INT TERM
+
+tar -xzf "$archive" -C "$staging_root"
+set -- "$staging_root"/Dropout_*_linux_x86_64-musl
+if [ "$#" -ne 1 ] || [ ! -d "$1" ]; then
+  echo "musl archive must contain exactly one package directory" >&2
+  exit 1
+fi
+
+package_root=$1
+for required_path in dropout README.md dropout.desktop dropout.png; do
+  if [ ! -f "$package_root/$required_path" ]; then
+    echo "musl archive is missing $required_path" >&2
+    exit 1
+  fi
+done
+if [ ! -x "$package_root/dropout" ]; then
+  echo "packaged musl binary is not executable" >&2
+  exit 1
+fi
+
+case "$mode" in
+  archive-only) ;;
+  full)
+    script_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+    "$script_dir/verify-linux-musl.sh" "$package_root/dropout"
+    ;;
+  *)
+    echo "unknown musl verification mode: $mode" >&2
+    exit 1
+    ;;
+esac
+
+echo "Verified packaged musl release: $archive_name"

--- a/scripts/verify-linux-musl.sh
+++ b/scripts/verify-linux-musl.sh
@@ -1,0 +1,37 @@
+#!/bin/sh
+set -eu
+
+binary_path="${1:-target/x86_64-unknown-linux-musl/release/dropout}"
+
+if [ ! -x "$binary_path" ]; then
+  echo "musl binary is missing or not executable: $binary_path" >&2
+  exit 1
+fi
+
+file "$binary_path" | tee /tmp/dropout-file.txt
+grep -q 'ELF 64-bit' /tmp/dropout-file.txt
+
+readelf -l "$binary_path" | tee /tmp/dropout-readelf.txt
+grep -q '/lib/ld-musl-x86_64.so.1' /tmp/dropout-readelf.txt
+
+ldd "$binary_path" | tee /tmp/dropout-ldd.txt
+if grep -q 'not found' /tmp/dropout-ldd.txt; then
+  echo "one or more musl runtime libraries are missing" >&2
+  exit 1
+fi
+
+set +e
+timeout 10s dbus-run-session -- xvfb-run -a "$binary_path" >/tmp/dropout-smoke.log 2>&1
+smoke_status=$?
+set -e
+
+case "$smoke_status" in
+  124 | 143) ;;
+  *)
+    cat /tmp/dropout-smoke.log >&2
+    echo "DropOut exited unexpectedly during the musl smoke test (status $smoke_status)" >&2
+    exit 1
+    ;;
+esac
+
+echo "DropOut remained running for the 10-second musl smoke window."

--- a/scripts/verify-linux-musl.sh
+++ b/scripts/verify-linux-musl.sh
@@ -8,14 +8,29 @@ if [ ! -x "$binary_path" ]; then
   exit 1
 fi
 
-file "$binary_path" | tee /tmp/dropout-file.txt
-grep -q 'ELF 64-bit' /tmp/dropout-file.txt
+if ! file_output=$(file "$binary_path" 2>&1); then
+  printf '%s\n' "$file_output" >&2
+  echo "failed to inspect the musl binary format" >&2
+  exit 1
+fi
+printf '%s\n' "$file_output"
+printf '%s\n' "$file_output" | grep -q 'ELF 64-bit'
 
-readelf -l "$binary_path" | tee /tmp/dropout-readelf.txt
-grep -q '/lib/ld-musl-x86_64.so.1' /tmp/dropout-readelf.txt
+if ! readelf_output=$(readelf -l "$binary_path" 2>&1); then
+  printf '%s\n' "$readelf_output" >&2
+  echo "failed to inspect the musl ELF interpreter" >&2
+  exit 1
+fi
+printf '%s\n' "$readelf_output"
+printf '%s\n' "$readelf_output" | grep -q '/lib/ld-musl-x86_64.so.1'
 
-ldd "$binary_path" | tee /tmp/dropout-ldd.txt
-if grep -q 'not found' /tmp/dropout-ldd.txt; then
+if ! ldd_output=$(ldd "$binary_path" 2>&1); then
+  printf '%s\n' "$ldd_output" >&2
+  echo "failed to inspect musl runtime libraries" >&2
+  exit 1
+fi
+printf '%s\n' "$ldd_output"
+if printf '%s\n' "$ldd_output" | grep -q 'not found'; then
   echo "one or more musl runtime libraries are missing" >&2
   exit 1
 fi


### PR DESCRIPTION
## Summary

- build a native x86_64 musl launcher from the committed `Cargo.lock` in a pinned Alpine 3.22 container
- package a deterministic tarball plus SHA-256 file, then verify that exact archive in a clean runtime-only Alpine stage
- reject checksum corruption, unsafe paths, incomplete package contents, missing execute permissions, unresolved libraries, and early headless startup exits
- create signed Sigstore/SLSA provenance for every downloaded desktop artifact before Semifold publishes it
- document checksum and `gh attestation verify` workflows in English and Chinese

## Runtime and provenance verification

- application dependencies match the documented Alpine runtime packages
- `binutils`, `file`, `musl-utils`, D-Bus, and Xvfb are installed separately as smoke-test tooling
- the final scratch artifact is copied from the verified runtime stage, so packaging cannot bypass the smoke test
- GitHub OIDC and `actions/attest@v4` bind each artifact digest to this repository's release workflow

## Validation

- `scripts/test-linux-musl-release.sh`
- `scripts/test-release-provenance.sh`
- POSIX shell syntax checks for all musl and release-contract scripts
- `pnpm exec prek run --all-files`
- `pnpm -C packages/docs build`
- `pnpm deploy:docs:dry-run`
- GitHub `Build on Linux x86_64 (Musl)` performs the full clean-Alpine build and packaged-runtime smoke test

Closes #73
