### PR TITLE
fix(ui): read launcher version dynamically

### DIFF
--- a/DEVELOPMENT_ROADMAP.md
+++ b/DEVELOPMENT_ROADMAP.md
@@ -2,7 +2,7 @@
 
 > **目标读者**: Claude Opus 4（AI 开发助手）
 > **项目**: DropOut — 基于 Tauri v2 的现代 Minecraft 启动器
-> **当前版本**: 0.2.0-alpha.6
+> **当前版本**: 0.2.0-alpha.7
 > **生成日期**: 2026-04-03
 
 ---
@@ -866,7 +866,7 @@ export function createInstance(name: string, customDir?: string | null): Promise
 
 **项目信息**:
 - GitHub 仓库: `HydroRoll-Team/DropOut`（发布页: https://github.com/HydroRoll-Team/DropOut/releases）
-- 当前版本: `0.2.0-alpha.6`
+- 当前版本: `0.2.0-alpha.7`
 - Tauri 版本: 2.9
 - 项目已有 GitHub Releases 集成（`get_github_releases` 命令）
 

--- a/packages/ui/src/pages/settings.tsx
+++ b/packages/ui/src/pages/settings.tsx
@@ -1,4 +1,5 @@
 import { getVersion } from "@tauri-apps/api/app";
+import { isTauri } from "@tauri-apps/api/core";
 import { toNumber } from "es-toolkit/compat";
 import { FileJsonIcon } from "lucide-react";
 import { useEffect, useState } from "react";
@@ -51,6 +52,8 @@ export function SettingsPage() {
   const navigate = useNavigate();
 
   useEffect(() => {
+    if (!isTauri()) return;
+
     let mounted = true;
 
     getVersion()

--- a/packages/ui/src/pages/settings.tsx
+++ b/packages/ui/src/pages/settings.tsx
@@ -1,3 +1,4 @@
+import { getVersion } from "@tauri-apps/api/app";
 import { toNumber } from "es-toolkit/compat";
 import { FileJsonIcon } from "lucide-react";
 import { useEffect, useState } from "react";
@@ -46,7 +47,22 @@ export function SettingsPage() {
   const updater = useUpdater();
   const { t } = useTranslation();
   const [activeTab, setActiveTab] = useState<SettingsTab>("general");
+  const [appVersion, setAppVersion] = useState<string | null>(null);
   const navigate = useNavigate();
+
+  useEffect(() => {
+    let mounted = true;
+
+    getVersion()
+      .then((version) => {
+        if (mounted) setAppVersion(version);
+      })
+      .catch((error) => console.error("Failed to read app version", error));
+
+    return () => {
+      mounted = false;
+    };
+  }, []);
 
   useEffect(() => {
     const refresh = async () => {
@@ -645,7 +661,9 @@ export function SettingsPage() {
                         <FieldLabel>
                           {t("settings.advanced.currentVersion")}
                         </FieldLabel>
-                        <FieldDescription>v0.2.0-alpha.6</FieldDescription>
+                        <FieldDescription>
+                          {appVersion ? `v${appVersion}` : "—"}
+                        </FieldDescription>
                       </FieldContent>
                       <Button
                         variant="outline"

--- a/packages/ui/tests/launcher-fixtures.spec.ts
+++ b/packages/ui/tests/launcher-fixtures.spec.ts
@@ -224,6 +224,24 @@ test("primary launcher flow is keyboard operable", async ({ page }) => {
   ).toBeVisible();
 });
 
+test("settings reports the current launcher version", async ({ page }) => {
+  await page.addInitScript(() => {
+    Object.defineProperty(window, "__TAURI_INTERNALS__", {
+      value: {
+        invoke: async (command: string) => {
+          if (command === "plugin:app|version") return "9.8.7-test";
+          throw new Error(`Unexpected Tauri command: ${command}`);
+        },
+      },
+    });
+  });
+  await page.goto("/?fixture=ready&theme=dark#/settings");
+  await page.getByRole("tab", { name: "Advanced" }).click();
+
+  await expect(page.getByText("Current version")).toBeVisible();
+  await expect(page.getByText("v9.8.7-test", { exact: true })).toBeVisible();
+});
+
 test("home primary action follows launcher recovery state", async ({
   page,
 }) => {

--- a/packages/ui/tests/launcher-fixtures.spec.ts
+++ b/packages/ui/tests/launcher-fixtures.spec.ts
@@ -226,8 +226,15 @@ test("primary launcher flow is keyboard operable", async ({ page }) => {
 
 test("settings reports the current launcher version", async ({ page }) => {
   await page.addInitScript(() => {
+    const existingInternals = Reflect.get(window, "__TAURI_INTERNALS__");
+    Object.assign(window, { isTauri: true });
     Object.defineProperty(window, "__TAURI_INTERNALS__", {
+      configurable: true,
+      writable: true,
       value: {
+        ...(typeof existingInternals === "object" && existingInternals !== null
+          ? existingInternals
+          : {}),
         invoke: async (command: string) => {
           if (command === "plugin:app|version") return "9.8.7-test";
           throw new Error(`Unexpected Tauri command: ${command}`);
@@ -240,6 +247,24 @@ test("settings reports the current launcher version", async ({ page }) => {
 
   await expect(page.getByText("Current version")).toBeVisible();
   await expect(page.getByText("v9.8.7-test", { exact: true })).toBeVisible();
+});
+
+test("settings avoids version errors outside the Tauri runtime", async ({
+  page,
+}) => {
+  const consoleErrors: string[] = [];
+  page.on("console", (message) => {
+    if (message.type() === "error") consoleErrors.push(message.text());
+  });
+
+  await page.goto("/?fixture=ready&theme=dark#/settings");
+  await page.getByRole("tab", { name: "Advanced" }).click();
+
+  await expect(page.getByText("Current version")).toBeVisible();
+  await expect(page.getByText("—", { exact: true })).toBeVisible();
+  expect(consoleErrors).not.toContainEqual(
+    expect.stringContaining("Failed to read app version"),
+  );
 });
 
 test("home primary action follows launcher recovery state", async ({


### PR DESCRIPTION
## Summary
- read the displayed launcher version from the Tauri app metadata
- add an end-to-end regression for the runtime version boundary
- align the development roadmap with 0.2.0-alpha.7

## Validation
- `pnpm -C packages/ui build`
- `pnpm exec biome check packages/ui/src/pages/settings.tsx packages/ui/tests/launcher-fixtures.spec.ts`
- `pnpm --filter @dropout/ui test:ui` (110 passed)
- `pnpm exec prek run --files DEVELOPMENT_ROADMAP.md packages/ui/src/pages/settings.tsx packages/ui/tests/launcher-fixtures.spec.ts`

## Summary by Sourcery

Read and display the launcher version dynamically from the Tauri app metadata and align documentation and tests with the new version behavior.

New Features:
- Display the current launcher version in the settings page using the Tauri app metadata instead of a hardcoded value.

Documentation:
- Update the development roadmap to reflect version 0.2.0-alpha.7 as the current launcher version.

Tests:
- Add an end-to-end test to verify that the settings page reports the launcher version sourced from the Tauri runtime.