### PR TITLE
ci: allow slow Linux dependency installs

### DIFF
--- a/.github/workflows/semifold-ci.yaml
+++ b/.github/workflows/semifold-ci.yaml
@@ -57,7 +57,7 @@ jobs:
 
       - name: Install Dependencies (Linux)
         if: runner.os == 'Linux'
-        timeout-minutes: 15
+        timeout-minutes: 30
         run: |
           sudo tee /etc/apt/apt.conf.d/99github-actions-retries >/dev/null <<'EOF'
           Acquire::Retries "5";


### PR DESCRIPTION
## Summary
- raise the Linux system-dependency step timeout from 15 to 30 minutes
- keep the existing apt retry and network timeout behavior unchanged

## Why
Alpha 7 release run 30827358053 timed out twice while downloading Ubuntu WebKit packages from the Azure mirror. All other platform builds passed, and no release was published.

## Validation
- `pnpm exec prek run --files .github/workflows/semifold-ci.yaml`
- `git diff --check`

## Summary by Sourcery

CI:
- Extend the Linux system dependency installation step timeout from 15 to 30 minutes in the semifold CI workflow.