### PR TITLE
fix(release): gate AUR on GitHub release

### DIFF
--- a/.github/workflows/semifold-ci.yaml
+++ b/.github/workflows/semifold-ci.yaml
@@ -284,11 +284,17 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          version=$(jq -r '.version' src-tauri/tauri.conf.json)
-          if gh release view "dropout-v$version" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+          set -euo pipefail
+          version=$(jq -re '.version' src-tauri/tauri.conf.json)
+          if output=$(gh release view "dropout-v$version" --repo "$GITHUB_REPOSITORY" 2>&1); then
             echo "published=true" >> "$GITHUB_OUTPUT"
           else
-            echo "published=false" >> "$GITHUB_OUTPUT"
+            if printf '%s\n' "$output" | grep -qi 'not found'; then
+              echo "published=false" >> "$GITHUB_OUTPUT"
+            else
+              printf '%s\n' "$output" >&2
+              exit 1
+            fi
           fi
       - name: Install pnpm
         if: steps.release-check.outputs.published == 'true'

--- a/.github/workflows/semifold-ci.yaml
+++ b/.github/workflows/semifold-ci.yaml
@@ -279,25 +279,42 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+      - name: Check matching GitHub release
+        id: release-check
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          version=$(jq -r '.version' src-tauri/tauri.conf.json)
+          if gh release view "dropout-v$version" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            echo "published=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "published=false" >> "$GITHUB_OUTPUT"
+          fi
       - name: Install pnpm
+        if: steps.release-check.outputs.published == 'true'
         uses: pnpm/action-setup@v4
       - name: Install Node.js
+        if: steps.release-check.outputs.published == 'true'
         uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: "pnpm"
           cache-dependency-path: "pnpm-lock.yaml"
       - name: Install Makepkg
+        if: steps.release-check.outputs.published == 'true'
         run: sudo apt-get update && sudo apt-get install -y makepkg pacman
       - name: Install Node.js Dependencies
+        if: steps.release-check.outputs.published == 'true'
         run: pnpm install --frozen-lockfile
       - name: Download Linux build artifacts
+        if: steps.release-check.outputs.published == 'true'
         uses: actions/download-artifact@v6
         with:
           pattern: linux-*-artifacts
           path: artifacts/
           merge-multiple: true
       - name: Publish AUR package
+        if: steps.release-check.outputs.published == 'true'
         run: pnpm exec tsx scripts/release-aur.ts
         env:
           AUR_SSH_KEY: ${{ secrets.AUR_SSH_PRIVATE_KEY }}

--- a/.github/workflows/semifold-ci.yaml
+++ b/.github/workflows/semifold-ci.yaml
@@ -280,7 +280,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
       - name: Check matching GitHub release
-        id: release-check
+        id: release_check
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -297,30 +297,30 @@ jobs:
             fi
           fi
       - name: Install pnpm
-        if: steps.release-check.outputs.published == 'true'
+        if: steps.release_check.outputs.published == 'true'
         uses: pnpm/action-setup@v4
       - name: Install Node.js
-        if: steps.release-check.outputs.published == 'true'
+        if: steps.release_check.outputs.published == 'true'
         uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: "pnpm"
           cache-dependency-path: "pnpm-lock.yaml"
       - name: Install Makepkg
-        if: steps.release-check.outputs.published == 'true'
+        if: steps.release_check.outputs.published == 'true'
         run: sudo apt-get update && sudo apt-get install -y makepkg pacman
       - name: Install Node.js Dependencies
-        if: steps.release-check.outputs.published == 'true'
+        if: steps.release_check.outputs.published == 'true'
         run: pnpm install --frozen-lockfile
       - name: Download Linux build artifacts
-        if: steps.release-check.outputs.published == 'true'
+        if: steps.release_check.outputs.published == 'true'
         uses: actions/download-artifact@v6
         with:
           pattern: linux-*-artifacts
           path: artifacts/
           merge-multiple: true
       - name: Publish AUR package
-        if: steps.release-check.outputs.published == 'true'
+        if: steps.release_check.outputs.published == 'true'
         run: pnpm exec tsx scripts/release-aur.ts
         env:
           AUR_SSH_KEY: ${{ secrets.AUR_SSH_PRIVATE_KEY }}

--- a/scripts/release-workflow.test.mjs
+++ b/scripts/release-workflow.test.mjs
@@ -46,6 +46,22 @@ test("publishes AUR in a rerunnable job after the GitHub release", () => {
     aurJob.steps.some(({ run }) => run?.includes("tsx scripts/release-aur.ts")),
     true,
   );
+
+  const releaseGateIndex = aurJob.steps.findIndex(
+    ({ id }) => id === "release-check",
+  );
+  assert.ok(releaseGateIndex > 0, "AUR release gate is missing");
+  assert.match(
+    aurJob.steps[releaseGateIndex].run ?? "",
+    /gh release view "dropout-v\$version"/,
+  );
+  for (const step of aurJob.steps.slice(releaseGateIndex + 1)) {
+    assert.equal(
+      step.if,
+      "steps.release-check.outputs.published == 'true'",
+      `${step.name} must wait for a matching GitHub release`,
+    );
+  }
 });
 
 test("does not run AUR before Semifold creates the GitHub release", () => {

--- a/scripts/release-workflow.test.mjs
+++ b/scripts/release-workflow.test.mjs
@@ -55,6 +55,13 @@ test("publishes AUR in a rerunnable job after the GitHub release", () => {
     aurJob.steps[releaseGateIndex].run ?? "",
     /gh release view "dropout-v\$version"/,
   );
+  assert.match(aurJob.steps[releaseGateIndex].run ?? "", /set -euo pipefail/);
+  assert.match(aurJob.steps[releaseGateIndex].run ?? "", /jq -re/);
+  assert.match(
+    aurJob.steps[releaseGateIndex].run ?? "",
+    /grep -qi 'not found'/,
+  );
+  assert.match(aurJob.steps[releaseGateIndex].run ?? "", /exit 1/);
   for (const step of aurJob.steps.slice(releaseGateIndex + 1)) {
     assert.equal(
       step.if,

--- a/scripts/release-workflow.test.mjs
+++ b/scripts/release-workflow.test.mjs
@@ -48,7 +48,7 @@ test("publishes AUR in a rerunnable job after the GitHub release", () => {
   );
 
   const releaseGateIndex = aurJob.steps.findIndex(
-    ({ id }) => id === "release-check",
+    ({ id }) => id === "release_check",
   );
   assert.ok(releaseGateIndex > 0, "AUR release gate is missing");
   assert.match(
@@ -65,7 +65,7 @@ test("publishes AUR in a rerunnable job after the GitHub release", () => {
   for (const step of aurJob.steps.slice(releaseGateIndex + 1)) {
     assert.equal(
       step.if,
-      "steps.release-check.outputs.published == 'true'",
+      "steps.release_check.outputs.published == 'true'",
       `${step.name} must wait for a matching GitHub release`,
     );
   }


### PR DESCRIPTION
## Summary

- skip AUR publishing when the current version has no matching GitHub Release
- keep the AUR job rerunnable once the release exists
- lock the gate and every dependent step into the release workflow contract

## Validation

- pnpm test:release
- pnpm test:parity
- pnpm exec prek run --all-files

## Summary by Sourcery

Gate AUR publishing in the release workflow on the existence of a matching GitHub release and keep the job rerunnable once the release is created.

CI:
- Add a release-check step to the AUR job and condition all subsequent steps on a matching GitHub release being present.

Tests:
- Extend release workflow tests to assert the presence of the AUR release gate and that all dependent steps are conditioned on the gate output.