### PR TITLE
fix(build): align Tauri CLI with Rust runtime

### DIFF
--- a/.changes/fix-tauri-bundle-type.md
+++ b/.changes/fix-tauri-bundle-type.md
@@ -1,0 +1,5 @@
+---
+dropout: "patch:fix"
+---
+
+Align the Tauri CLI with the Rust runtime so Linux packages retain the bundle-type metadata required by the updater.

--- a/.github/docker/linux-musl.Dockerfile
+++ b/.github/docker/linux-musl.Dockerfile
@@ -35,7 +35,6 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/workspace/target \
     --mount=type=cache,target=/root/.local/share/pnpm/store \
     pnpm install --frozen-lockfile \
-    && pnpm -C packages/ui --lockfile-dir /workspace install --frozen-lockfile \
     && pnpm exec tauri build --target x86_64-unknown-linux-musl --no-bundle \
     && scripts/package-linux-musl.sh target/x86_64-unknown-linux-musl/release/dropout artifacts
 

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -31,7 +31,7 @@ jobs:
           cache: "pnpm"
           cache-dependency-path: "pnpm-lock.yaml"
 
-      - run: pnpm -C packages/ui --lockfile-dir "${{ github.workspace }}" install --frozen-lockfile
+      - run: pnpm install --frozen-lockfile
 
       - name: Lint UI
         run: pnpm biome ci

--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -35,7 +35,7 @@ jobs:
           cache-dependency-path: "pnpm-lock.yaml"
 
       - name: Install Dependencies
-        run: pnpm -C packages/docs --lockfile-dir "${{ github.workspace }}" install --frozen-lockfile
+        run: pnpm install --frozen-lockfile
 
       - name: Build Docs
         working-directory: packages/docs

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -29,7 +29,7 @@ jobs:
           cache: "pnpm"
           cache-dependency-path: "pnpm-lock.yaml"
 
-      - run: pnpm -C packages/ui --lockfile-dir "${{ github.workspace }}" install --frozen-lockfile
+      - run: pnpm install --frozen-lockfile
 
       - run: pnpm lint --fix
         working-directory: packages/ui

--- a/.github/workflows/semifold-ci.yaml
+++ b/.github/workflows/semifold-ci.yaml
@@ -95,9 +95,6 @@ jobs:
       - name: Install Root Node.js Dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Install UI Dependencies
-        run: pnpm -C packages/ui --lockfile-dir "${{ github.workspace }}" install --frozen-lockfile
-
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
         with:

--- a/.github/workflows/semifold-ci.yaml
+++ b/.github/workflows/semifold-ci.yaml
@@ -89,7 +89,7 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: 22
-          cache: "pnpm"
+          cache: ${{ runner.os != 'Windows' && 'pnpm' || '' }}
           cache-dependency-path: "pnpm-lock.yaml"
 
       - name: Install Root Node.js Dependencies

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -79,7 +79,7 @@ jobs:
 
       - name: Install Frontend Dependencies
         if: github.event_name == 'workflow_dispatch'
-        run: pnpm -C packages/ui --lockfile-dir "${{ github.workspace }}" install --frozen-lockfile
+        run: pnpm install --frozen-lockfile
 
       - name: Install Tauri CLI
         if: github.event_name == 'workflow_dispatch'

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
     "modpack"
   ],
   "license": "AGPL-3.0-or-later",
-  "packageManager": "pnpm@10.30.2",
   "dependencies": {
     "consola": "^3.4.2",
     "toml": "^3.0.0"
@@ -30,49 +29,11 @@
   "devDependencies": {
     "@biomejs/biome": "^2.4.9",
     "@j178/prek": "^0.2.29",
-    "@tauri-apps/cli": "^2.9.6",
+    "@tauri-apps/cli": "^2.11.4",
     "@types/node": "^24.10.9",
     "js-yaml": "^4.1.0",
     "smol-toml": "^1.7.1",
     "tsx": "^4.21.0",
     "wrangler": "^4.111.0"
-  },
-  "pnpm": {
-    "overrides": {
-      "vite": "npm:rolldown-vite@^7",
-      "@babel/core": "7.29.6",
-      "axios": "1.16.0",
-      "brace-expansion": "5.0.6",
-      "dompurify": "3.4.11",
-      "express-rate-limit": "8.2.2",
-      "fast-uri": "3.1.2",
-      "fsevents": "2.3.3",
-      "follow-redirects": "1.16.0",
-      "form-data": "4.0.6",
-      "hono": "4.12.25",
-      "@hono/node-server": "1.19.13",
-      "@isaacs/brace-expansion": "5.0.1",
-      "ip-address": "10.1.1",
-      "js-yaml": "4.2.0",
-      "launch-editor": "2.14.1",
-      "lodash": "4.18.1",
-      "lodash-es": "4.18.1",
-      "mermaid": "11.15.0",
-      "minimatch": "10.2.3",
-      "morgan": "1.11.0",
-      "path-to-regexp": "0.1.13",
-      "picomatch": "2.3.2",
-      "postcss": "8.5.10",
-      "qs": "6.15.2",
-      "seroval": "1.4.1",
-      "shell-quote": "1.8.4",
-      "uuid": "11.1.1",
-      "ws": "8.21.0"
-    },
-    "onlyBuiltDependencies": [
-      "core-js",
-      "esbuild",
-      "msw"
-    ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "modpack"
   ],
   "license": "AGPL-3.0-or-later",
+  "packageManager": "pnpm@next-12",
   "dependencies": {
     "consola": "^3.4.2",
     "toml": "^3.0.0"

--- a/packages/docs/README.md
+++ b/packages/docs/README.md
@@ -38,8 +38,7 @@ The current i18n source of truth is `app/lib/i18n.ts`: default language `zh`, la
 Run commands from the repository root unless you are already inside `packages/docs`.
 
 ```bash
-pnpm install
-pnpm -C packages/docs --lockfile-dir "$PWD" install
+pnpm install --frozen-lockfile
 pnpm -C packages/docs dev
 ```
 
@@ -137,7 +136,7 @@ The docs site is deployed as a Cloudflare Worker with static assets. The root
 asset binding, compatibility date, and observability settings.
 
 ```bash
-pnpm -C packages/docs --lockfile-dir "$PWD" install
+pnpm install --frozen-lockfile
 pnpm -C packages/docs build
 pnpm deploy:docs:dry-run
 pnpm deploy:docs

--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -7,7 +7,7 @@ The React launcher UI normally runs inside Tauri. Development fixtures provide d
 Run package commands from the repository root and keep the shared root lockfile authoritative:
 
 ```bash
-pnpm -C packages/ui --lockfile-dir "$PWD" install --frozen-lockfile
+pnpm install --frozen-lockfile
 pnpm -C packages/ui dev
 ```
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,10 +51,10 @@ importers:
         version: 2.4.9
       '@j178/prek':
         specifier: ^0.2.29
-        version: 0.2.29
+        version: 0.2.29(debug@4.4.3(supports-color@10.2.2))
       '@tauri-apps/cli':
-        specifier: ^2.9.6
-        version: 2.9.6
+        specifier: ^2.11.4
+        version: 2.11.4
       '@types/node':
         specifier: ^24.10.9
         version: 24.10.9
@@ -2259,13 +2259,6 @@ packages:
     resolution: {integrity: sha512-LffYTvPjODiP6PT16oNeUQJzNVyJl1cjIebq/rWWBF+3eDst5JGEFSc5cWxyRCJ0Mxl+KyIkqRxk1XPEs9x8TA==}
     engines: {node: '>=14.0.0'}
     cpu: [wasm32]
-    bundledDependencies:
-      - '@napi-rs/wasm-runtime'
-      - '@emnapi/core'
-      - '@emnapi/runtime'
-      - '@tybys/wasm-util'
-      - '@emnapi/wasi-threads'
-      - tslib
 
   '@tailwindcss/oxide-win32-arm64-msvc@4.1.18':
     resolution: {integrity: sha512-HjSA7mr9HmC8fu6bdsZvZ+dhjyGCLdotjVOgLA2vEqxEBZaQo9YTX4kwgEvPCpRh8o4uWc4J/wEoFzhEmjvPbA==}
@@ -2333,79 +2326,79 @@ packages:
   '@tauri-apps/api@2.9.1':
     resolution: {integrity: sha512-IGlhP6EivjXHepbBic618GOmiWe4URJiIeZFlB7x3czM0yDHHYviH1Xvoiv4FefdkQtn6v7TuwWCRfOGdnVUGw==}
 
-  '@tauri-apps/cli-darwin-arm64@2.9.6':
-    resolution: {integrity: sha512-gf5no6N9FCk1qMrti4lfwP77JHP5haASZgVbBgpZG7BUepB3fhiLCXGUK8LvuOjP36HivXewjg72LTnPDScnQQ==}
+  '@tauri-apps/cli-darwin-arm64@2.11.4':
+    resolution: {integrity: sha512-1ryOF3ZhpZ/nemHV5zVwBQBz9jDGKmKPvWPADOhc83ig0P4bMc2iER4NbC6r9sjeIZ6RVQ4g3RZIYvezhcl4TQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [darwin]
 
-  '@tauri-apps/cli-darwin-x64@2.9.6':
-    resolution: {integrity: sha512-oWh74WmqbERwwrwcueJyY6HYhgCksUc6NT7WKeXyrlY/FPmNgdyQAgcLuTSkhRFuQ6zh4Np1HZpOqCTpeZBDcw==}
+  '@tauri-apps/cli-darwin-x64@2.11.4':
+    resolution: {integrity: sha512-uFsGQAAfuyz1k/yGLmkWfkBlgKAqZfxqlHmLWx81QU27RJWfmbNHCIq8T8w1e+VClleIuZUjpHWfoE4E3DLo3A==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [darwin]
 
-  '@tauri-apps/cli-linux-arm-gnueabihf@2.9.6':
-    resolution: {integrity: sha512-/zde3bFroFsNXOHN204DC2qUxAcAanUjVXXSdEGmhwMUZeAQalNj5cz2Qli2elsRjKN/hVbZOJj0gQ5zaYUjSg==}
+  '@tauri-apps/cli-linux-arm-gnueabihf@2.11.4':
+    resolution: {integrity: sha512-IaHZn5CdBL21oUmjiVOS1ctw6Ip1O0pjp70FwOWmYz1myWe0SY96ZIj2FYf7pT0m8bI2h/hrs5ZbEXXh44/MkQ==}
     engines: {node: '>= 10'}
     cpu: [arm]
     os: [linux]
 
-  '@tauri-apps/cli-linux-arm64-gnu@2.9.6':
-    resolution: {integrity: sha512-pvbljdhp9VOo4RnID5ywSxgBs7qiylTPlK56cTk7InR3kYSTJKYMqv/4Q/4rGo/mG8cVppesKIeBMH42fw6wjg==}
+  '@tauri-apps/cli-linux-arm64-gnu@2.11.4':
+    resolution: {integrity: sha512-N41/ukTRVe6XSuUTESuFdGeOW2i7k62tK+6gHK5Kd5/q5RPvvi19GaWAVPPb9u95HSGmTChSolBfzynUsssFaA==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@tauri-apps/cli-linux-arm64-musl@2.9.6':
-    resolution: {integrity: sha512-02TKUndpodXBCR0oP//6dZWGYcc22Upf2eP27NvC6z0DIqvkBBFziQUcvi2n6SrwTRL0yGgQjkm9K5NIn8s6jw==}
+  '@tauri-apps/cli-linux-arm64-musl@2.11.4':
+    resolution: {integrity: sha512-v277UnT/fB64xAfSroL5N3Km3tLmvATWqJJw/wRI+g6o+HkeD0slyE7gOhNs1MbjE41R7bQOTxMVoL3aomUJmw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@tauri-apps/cli-linux-riscv64-gnu@2.9.6':
-    resolution: {integrity: sha512-fmp1hnulbqzl1GkXl4aTX9fV+ubHw2LqlLH1PE3BxZ11EQk+l/TmiEongjnxF0ie4kV8DQfDNJ1KGiIdWe1GvQ==}
+  '@tauri-apps/cli-linux-riscv64-gnu@2.11.4':
+    resolution: {integrity: sha512-qqgNkQ2u1yZHxjhxsZaxUtRDW8dIqIYm33rx/mzwQv0SfY9x1B+iraj8vWeFiXjjSVVhEMepXSOts1TqPzvXNQ==}
     engines: {node: '>= 10'}
     cpu: [riscv64]
     os: [linux]
     libc: [glibc]
 
-  '@tauri-apps/cli-linux-x64-gnu@2.9.6':
-    resolution: {integrity: sha512-vY0le8ad2KaV1PJr+jCd8fUF9VOjwwQP/uBuTJvhvKTloEwxYA/kAjKK9OpIslGA9m/zcnSo74czI6bBrm2sYA==}
+  '@tauri-apps/cli-linux-x64-gnu@2.11.4':
+    resolution: {integrity: sha512-2VRNWl84FOH0m2giiDkO2h0QXlcMJeX+zJDpI5kDIQAx6s+geF3v48F4DXfJez4GS/FdoDGnPnw1C2iYGbQ7bQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@tauri-apps/cli-linux-x64-musl@2.9.6':
-    resolution: {integrity: sha512-TOEuB8YCFZTWVDzsO2yW0+zGcoMiPPwcUgdnW1ODnmgfwccpnihDRoks+ABT1e3fHb1ol8QQWsHSCovb3o2ENQ==}
+  '@tauri-apps/cli-linux-x64-musl@2.11.4':
+    resolution: {integrity: sha512-o9GyhYor/nc7xarmwDE3ka2szuW3uuZzXjHWh64Q8YX5AtSgxdQkFWzrY4O8KiGtVNvFBI14H3Q49Qj5TOIP/A==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@tauri-apps/cli-win32-arm64-msvc@2.9.6':
-    resolution: {integrity: sha512-ujmDGMRc4qRLAnj8nNG26Rlz9klJ0I0jmZs2BPpmNNf0gM/rcVHhqbEkAaHPTBVIrtUdf7bGvQAD2pyIiUrBHQ==}
+  '@tauri-apps/cli-win32-arm64-msvc@2.11.4':
+    resolution: {integrity: sha512-ld5Ehb598m0VkYyylRPNeCFsBe/km0jxis6KgMpl3IGY6I/i1RwQXO05I1AsXUXO2WC6AvB/Lw4qTf/asiuEiQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [win32]
 
-  '@tauri-apps/cli-win32-ia32-msvc@2.9.6':
-    resolution: {integrity: sha512-S4pT0yAJgFX8QRCyKA1iKjZ9Q/oPjCZf66A/VlG5Yw54Nnr88J1uBpmenINbXxzyhduWrIXBaUbEY1K80ZbpMg==}
+  '@tauri-apps/cli-win32-ia32-msvc@2.11.4':
+    resolution: {integrity: sha512-12Hxi0XX/H5VFxO/bGgHkFWhml9VMgEOu9CidjeCeTNQ1l6fpUlbiGgSP7CLI3PFtW9/FfbeHieZ+kyWK5H7CA==}
     engines: {node: '>= 10'}
     cpu: [ia32]
     os: [win32]
 
-  '@tauri-apps/cli-win32-x64-msvc@2.9.6':
-    resolution: {integrity: sha512-ldWuWSSkWbKOPjQMJoYVj9wLHcOniv7diyI5UAJ4XsBdtaFB0pKHQsqw/ItUma0VXGC7vB4E9fZjivmxur60aw==}
+  '@tauri-apps/cli-win32-x64-msvc@2.11.4':
+    resolution: {integrity: sha512-+vDiqBIU5dMISg/wNvX3sF+ZHfgJGJ5T0AcO+EHNXV9GGAG+P5fzodlDXD3QdKCRgZxMoCm5PPvj3BqLNjBthw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
 
-  '@tauri-apps/cli@2.9.6':
-    resolution: {integrity: sha512-3xDdXL5omQ3sPfBfdC8fCtDKcnyV7OqyzQgfyT5P3+zY6lcPqIYKQBvUasNvppi21RSdfhy44ttvJmftb0PCDw==}
+  '@tauri-apps/cli@2.11.4':
+    resolution: {integrity: sha512-R8xGtMpwyetawSqm9kYOuMmEqkhUbvcUy8n0aNXIxollKBLESUu5f4Fx+64hgASYm1H+jSWq6jCW6zqTnH6hqQ==}
     engines: {node: '>= 10'}
     hasBin: true
 
@@ -4655,6 +4648,7 @@ packages:
   rolldown-vite@7.2.5:
     resolution: {integrity: sha512-u09tdk/huMiN8xwoiBbig197jKdCamQTtOruSalOzbqGje3jdHiV0njQlAW0YvzoahkirFePNQ4RYlfnRQpXZA==}
     engines: {node: ^20.19.0 || >=22.12.0}
+    deprecated: Use 7.3.1 for migration purposes. For the most recent updates, migrate to Vite 8 once you're ready.
     hasBin: true
     peerDependencies:
       '@types/node': ^20.19.0 || >=22.12.0
@@ -5251,7 +5245,7 @@ snapshots:
       '@babel/types': 7.29.7
       '@jridgewell/remapping': 2.3.5
       convert-source-map: 2.0.0
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@10.2.2)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -5457,7 +5451,7 @@ snapshots:
       '@babel/parser': 7.28.6
       '@babel/template': 7.28.6
       '@babel/types': 7.28.6
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@10.2.2)
     transitivePeerDependencies:
       - supports-color
 
@@ -5469,7 +5463,7 @@ snapshots:
       '@babel/parser': 7.29.7
       '@babel/template': 7.29.7
       '@babel/types': 7.29.7
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@10.2.2)
     transitivePeerDependencies:
       - supports-color
 
@@ -5931,9 +5925,9 @@ snapshots:
   '@img/sharp-win32-x64@0.34.5':
     optional: true
 
-  '@j178/prek@0.2.29':
+  '@j178/prek@0.2.29(debug@4.4.3(supports-color@10.2.2))':
     dependencies:
-      axios: 1.16.0
+      axios: 1.16.0(debug@4.4.3(supports-color@10.2.2))
       axios-proxy-builder: 0.1.2
       console.table: 0.10.0
       detect-libc: 2.1.2
@@ -7206,52 +7200,52 @@ snapshots:
 
   '@tauri-apps/api@2.9.1': {}
 
-  '@tauri-apps/cli-darwin-arm64@2.9.6':
+  '@tauri-apps/cli-darwin-arm64@2.11.4':
     optional: true
 
-  '@tauri-apps/cli-darwin-x64@2.9.6':
+  '@tauri-apps/cli-darwin-x64@2.11.4':
     optional: true
 
-  '@tauri-apps/cli-linux-arm-gnueabihf@2.9.6':
+  '@tauri-apps/cli-linux-arm-gnueabihf@2.11.4':
     optional: true
 
-  '@tauri-apps/cli-linux-arm64-gnu@2.9.6':
+  '@tauri-apps/cli-linux-arm64-gnu@2.11.4':
     optional: true
 
-  '@tauri-apps/cli-linux-arm64-musl@2.9.6':
+  '@tauri-apps/cli-linux-arm64-musl@2.11.4':
     optional: true
 
-  '@tauri-apps/cli-linux-riscv64-gnu@2.9.6':
+  '@tauri-apps/cli-linux-riscv64-gnu@2.11.4':
     optional: true
 
-  '@tauri-apps/cli-linux-x64-gnu@2.9.6':
+  '@tauri-apps/cli-linux-x64-gnu@2.11.4':
     optional: true
 
-  '@tauri-apps/cli-linux-x64-musl@2.9.6':
+  '@tauri-apps/cli-linux-x64-musl@2.11.4':
     optional: true
 
-  '@tauri-apps/cli-win32-arm64-msvc@2.9.6':
+  '@tauri-apps/cli-win32-arm64-msvc@2.11.4':
     optional: true
 
-  '@tauri-apps/cli-win32-ia32-msvc@2.9.6':
+  '@tauri-apps/cli-win32-ia32-msvc@2.11.4':
     optional: true
 
-  '@tauri-apps/cli-win32-x64-msvc@2.9.6':
+  '@tauri-apps/cli-win32-x64-msvc@2.11.4':
     optional: true
 
-  '@tauri-apps/cli@2.9.6':
+  '@tauri-apps/cli@2.11.4':
     optionalDependencies:
-      '@tauri-apps/cli-darwin-arm64': 2.9.6
-      '@tauri-apps/cli-darwin-x64': 2.9.6
-      '@tauri-apps/cli-linux-arm-gnueabihf': 2.9.6
-      '@tauri-apps/cli-linux-arm64-gnu': 2.9.6
-      '@tauri-apps/cli-linux-arm64-musl': 2.9.6
-      '@tauri-apps/cli-linux-riscv64-gnu': 2.9.6
-      '@tauri-apps/cli-linux-x64-gnu': 2.9.6
-      '@tauri-apps/cli-linux-x64-musl': 2.9.6
-      '@tauri-apps/cli-win32-arm64-msvc': 2.9.6
-      '@tauri-apps/cli-win32-ia32-msvc': 2.9.6
-      '@tauri-apps/cli-win32-x64-msvc': 2.9.6
+      '@tauri-apps/cli-darwin-arm64': 2.11.4
+      '@tauri-apps/cli-darwin-x64': 2.11.4
+      '@tauri-apps/cli-linux-arm-gnueabihf': 2.11.4
+      '@tauri-apps/cli-linux-arm64-gnu': 2.11.4
+      '@tauri-apps/cli-linux-arm64-musl': 2.11.4
+      '@tauri-apps/cli-linux-riscv64-gnu': 2.11.4
+      '@tauri-apps/cli-linux-x64-gnu': 2.11.4
+      '@tauri-apps/cli-linux-x64-musl': 2.11.4
+      '@tauri-apps/cli-win32-arm64-msvc': 2.11.4
+      '@tauri-apps/cli-win32-ia32-msvc': 2.11.4
+      '@tauri-apps/cli-win32-x64-msvc': 2.11.4
 
   '@tauri-apps/plugin-dialog@2.6.0':
     dependencies:
@@ -7533,9 +7527,9 @@ snapshots:
     dependencies:
       tunnel: 0.0.6
 
-  axios@1.16.0:
+  axios@1.16.0(debug@4.4.3(supports-color@10.2.2)):
     dependencies:
-      follow-redirects: 1.16.0
+      follow-redirects: 1.16.0(debug@4.4.3(supports-color@10.2.2))
       form-data: 4.0.6
       proxy-from-env: 2.1.0
     transitivePeerDependencies:
@@ -7583,7 +7577,7 @@ snapshots:
     dependencies:
       bytes: 3.1.2
       content-type: 1.0.5
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@10.2.2)
       http-errors: 2.0.1
       iconv-lite: 0.7.2
       on-finished: 2.4.1
@@ -7962,9 +7956,11 @@ snapshots:
     dependencies:
       ms: 2.0.0
 
-  debug@4.4.3:
+  debug@4.4.3(supports-color@10.2.2):
     dependencies:
       ms: 2.1.3
+    optionalDependencies:
+      supports-color: 10.2.2
 
   decode-named-character-reference@1.3.0:
     dependencies:
@@ -8284,7 +8280,7 @@ snapshots:
       content-type: 1.0.5
       cookie: 0.7.2
       cookie-signature: 1.2.2
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@10.2.2)
       depd: 2.0.0
       encodeurl: 2.0.0
       escape-html: 1.0.3
@@ -8355,7 +8351,7 @@ snapshots:
 
   finalhandler@2.1.1:
     dependencies:
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@10.2.2)
       encodeurl: 2.0.0
       escape-html: 1.0.3
       on-finished: 2.4.1
@@ -8364,7 +8360,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  follow-redirects@1.16.0: {}
+  follow-redirects@1.16.0(debug@4.4.3(supports-color@10.2.2)):
+    optionalDependencies:
+      debug: 4.4.3(supports-color@10.2.2)
 
   form-data@4.0.6:
     dependencies:
@@ -9324,7 +9322,7 @@ snapshots:
   micromark@4.0.2:
     dependencies:
       '@types/debug': 4.1.12
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@10.2.2)
       decode-named-character-reference: 1.3.0
       devlop: 1.1.0
       micromark-core-commonmark: 2.0.3
@@ -10012,7 +10010,7 @@ snapshots:
 
   router@2.2.0:
     dependencies:
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@10.2.2)
       depd: 2.0.0
       is-promise: 4.0.0
       parseurl: 1.3.3
@@ -10064,7 +10062,7 @@ snapshots:
 
   send@1.2.1:
     dependencies:
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@10.2.2)
       encodeurl: 2.0.0
       escape-html: 1.0.3
       etag: 1.8.1
@@ -10481,7 +10479,7 @@ snapshots:
   vite-node@3.2.4(@types/node@24.10.9)(jiti@2.6.1)(tsx@4.21.0):
     dependencies:
       cac: 6.7.14
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@10.2.2)
       es-module-lexer: 1.7.0
       pathe: 2.0.3
       vite: rolldown-vite@7.2.5(@types/node@24.10.9)(jiti@2.6.1)(tsx@4.21.0)
@@ -10501,7 +10499,7 @@ snapshots:
 
   vite-tsconfig-paths@6.0.4(rolldown-vite@7.2.5(@types/node@24.10.9)(jiti@2.6.1)(tsx@4.21.0))(typescript@5.9.3):
     dependencies:
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@10.2.2)
       globrex: 0.1.2
       tsconfck: 3.1.6(typescript@5.9.3)
     optionalDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,41 @@
 packages:
   - "packages/*"
+
+overrides:
+  vite: "npm:rolldown-vite@^7"
+  "@babel/core": "7.29.6"
+  axios: "1.16.0"
+  brace-expansion: "5.0.6"
+  dompurify: "3.4.11"
+  express-rate-limit: "8.2.2"
+  fast-uri: "3.1.2"
+  fsevents: "2.3.3"
+  follow-redirects: "1.16.0"
+  form-data: "4.0.6"
+  hono: "4.12.25"
+  "@hono/node-server": "1.19.13"
+  "@isaacs/brace-expansion": "5.0.1"
+  ip-address: "10.1.1"
+  js-yaml: "4.2.0"
+  launch-editor: "2.14.1"
+  lodash: "4.18.1"
+  lodash-es: "4.18.1"
+  mermaid: "11.15.0"
+  minimatch: "10.2.3"
+  morgan: "1.11.0"
+  path-to-regexp: "0.1.13"
+  picomatch: "2.3.2"
+  postcss: "8.5.10"
+  qs: "6.15.2"
+  seroval: "1.4.1"
+  shell-quote: "1.8.4"
+  uuid: "11.1.1"
+  ws: "8.21.0"
+
+allowBuilds:
+  "@j178/prek": false
+  core-js: true
+  esbuild: true
+  msw: true
+  sharp: false
+  workerd: false

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -38,12 +38,12 @@ sha1 = "0.10"
 sha2 = "0.10"
 sysinfo = { version = "0.39.6", default-features = false, features = ["system"] }
 tar = "0.4"
-tauri = { version = "2.9", features = ["tray-icon"] }
-tauri-plugin-dialog = "2.6.0"
-tauri-plugin-fs = "2.4.5"
+tauri = { version = "2.11.5", features = ["tray-icon"] }
+tauri-plugin-dialog = "2.7.2"
+tauri-plugin-fs = "2.5.1"
 tauri-plugin-notification = "2.3.3"
-tauri-plugin-shell = "2.3"
-tauri-plugin-updater = "2"
+tauri-plugin-shell = "2.3.5"
+tauri-plugin-updater = "2.10.1"
 tokio = { version = "1.49.0", features = ["full"] }
 toml = "0.5"
 ts-rs = { version = "11.1.0", features = ["serde-compat"] }
@@ -56,7 +56,7 @@ inventory = "0.3.21"
 
 [build-dependencies]
 dotenvy = { version = "0.15", default-features = false }
-tauri-build = { version = "2.0", features = [] }
+tauri-build = { version = "2.6.3", features = [] }
 
 [target.'cfg(all(windows, target_env = "gnu"))'.build-dependencies]
 embed-resource = "2.4"


### PR DESCRIPTION
## Summary by Sourcery

Align the Tauri toolchain and workspace dependency management to ensure consistent builds and updater-compatible Linux packages.

Bug Fixes:
- Align the Tauri CLI and Rust runtime versions so Linux packages preserve the bundle metadata required by the updater.

Enhancements:
- Centralize pnpm workspace dependency overrides and build permissions.
- Standardize dependency installation on the shared root lockfile across CI, Docker builds, and package documentation.

Build:
- Update pnpm and Tauri-related JavaScript and Rust dependencies to compatible versions.

CI:
- Use root-level dependency installation throughout CI and avoid unsupported pnpm caching on Windows.

Documentation:
- Update UI and documentation setup instructions to use the shared frozen lockfile installation.

Chores:
- Add a patch release note for the Tauri bundle metadata fix.