### PR TITLE
fix(java): handle ZGC flags on JDK 24+

### DIFF
--- a/.changes/fix-jdk24-zgc-compat.md
+++ b/.changes/fix-jdk24-zgc-compat.md
@@ -1,0 +1,5 @@
+---
+dropout: "patch:fix"
+---
+
+Avoid the removed `ZGenerational` JVM option when using the ZGC preset with JDK 24 and newer.

--- a/src-tauri/src/core/java/launch_args.rs
+++ b/src-tauri/src/core/java/launch_args.rs
@@ -93,6 +93,16 @@ mod tests {
     }
 
     #[test]
+    fn jvm_gc_preset_args_omits_zgenerational_for_jdk_26_early_access() {
+        let java_major = super::super::validation::parse_java_version("26-ea");
+
+        assert_eq!(
+            jvm_gc_preset_args("zgc", java_major),
+            expected_modern_zgc_args()
+        );
+    }
+
+    #[test]
     fn jvm_gc_preset_args_omits_zgenerational_on_future_jdks() {
         assert_eq!(jvm_gc_preset_args("zgc", 30), expected_modern_zgc_args());
     }

--- a/src-tauri/src/core/java/launch_args.rs
+++ b/src-tauri/src/core/java/launch_args.rs
@@ -1,0 +1,155 @@
+pub fn jvm_gc_preset_args(preset: &str, java_major: u32) -> Vec<String> {
+    match preset {
+        "g1gc" => vec![
+            "-XX:+UseG1GC".to_string(),
+            "-XX:+ParallelRefProcEnabled".to_string(),
+            "-XX:MaxGCPauseMillis=200".to_string(),
+            "-XX:+UnlockExperimentalVMOptions".to_string(),
+            "-XX:+DisableExplicitGC".to_string(),
+            "-XX:+AlwaysPreTouch".to_string(),
+            "-XX:G1NewSizePercent=30".to_string(),
+            "-XX:G1MaxNewSizePercent=40".to_string(),
+            "-XX:G1HeapRegionSize=8M".to_string(),
+            "-XX:G1ReservePercent=20".to_string(),
+            "-XX:G1HeapWastePercent=5".to_string(),
+            "-XX:G1MixedGCCountTarget=4".to_string(),
+            "-XX:InitiatingHeapOccupancyPercent=15".to_string(),
+            "-XX:G1MixedGCLiveThresholdPercent=90".to_string(),
+            "-XX:G1RSetUpdatingPauseTimePercent=5".to_string(),
+            "-XX:SurvivorRatio=32".to_string(),
+            "-XX:+PerfDisableSharedMem".to_string(),
+            "-XX:MaxTenuringThreshold=1".to_string(),
+        ],
+        "zgc" => {
+            let mut args = vec![
+                "-XX:+UseZGC".to_string(),
+                "-XX:+UnlockExperimentalVMOptions".to_string(),
+            ];
+
+            if java_major < 24 {
+                args.push("-XX:+ZGenerational".to_string());
+            }
+
+            args.push("-XX:+AlwaysPreTouch".to_string());
+            args.push("-XX:+DisableExplicitGC".to_string());
+            args
+        }
+        "shenandoah" => vec![
+            "-XX:+UseShenandoahGC".to_string(),
+            "-XX:+UnlockExperimentalVMOptions".to_string(),
+            "-XX:+AlwaysPreTouch".to_string(),
+            "-XX:+DisableExplicitGC".to_string(),
+            "-XX:ShenandoahGCHeuristics=adaptive".to_string(),
+        ],
+        _ => Vec::new(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn expected_legacy_zgc_args() -> Vec<String> {
+        [
+            "-XX:+UseZGC",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+ZGenerational",
+            "-XX:+AlwaysPreTouch",
+            "-XX:+DisableExplicitGC",
+        ]
+        .map(str::to_string)
+        .to_vec()
+    }
+
+    fn expected_modern_zgc_args() -> Vec<String> {
+        [
+            "-XX:+UseZGC",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+AlwaysPreTouch",
+            "-XX:+DisableExplicitGC",
+        ]
+        .map(str::to_string)
+        .to_vec()
+    }
+
+    #[test]
+    fn jvm_gc_preset_args_keeps_zgenerational_on_jdk_21() {
+        assert_eq!(jvm_gc_preset_args("zgc", 21), expected_legacy_zgc_args());
+    }
+
+    #[test]
+    fn jvm_gc_preset_args_keeps_zgenerational_on_jdk_23() {
+        assert_eq!(jvm_gc_preset_args("zgc", 23), expected_legacy_zgc_args());
+    }
+
+    #[test]
+    fn jvm_gc_preset_args_omits_zgenerational_on_jdk_24() {
+        assert_eq!(jvm_gc_preset_args("zgc", 24), expected_modern_zgc_args());
+    }
+
+    #[test]
+    fn jvm_gc_preset_args_omits_zgenerational_on_jdk_26() {
+        assert_eq!(jvm_gc_preset_args("zgc", 26), expected_modern_zgc_args());
+    }
+
+    #[test]
+    fn jvm_gc_preset_args_omits_zgenerational_on_future_jdks() {
+        assert_eq!(jvm_gc_preset_args("zgc", 30), expected_modern_zgc_args());
+    }
+
+    #[test]
+    fn jvm_gc_preset_args_preserves_legacy_zgc_behavior_for_unknown_java() {
+        assert_eq!(jvm_gc_preset_args("zgc", 0), expected_legacy_zgc_args());
+    }
+
+    #[test]
+    fn jvm_gc_preset_args_keeps_g1gc_independent_of_java_version() {
+        let expected = [
+            "-XX:+UseG1GC",
+            "-XX:+ParallelRefProcEnabled",
+            "-XX:MaxGCPauseMillis=200",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+DisableExplicitGC",
+            "-XX:+AlwaysPreTouch",
+            "-XX:G1NewSizePercent=30",
+            "-XX:G1MaxNewSizePercent=40",
+            "-XX:G1HeapRegionSize=8M",
+            "-XX:G1ReservePercent=20",
+            "-XX:G1HeapWastePercent=5",
+            "-XX:G1MixedGCCountTarget=4",
+            "-XX:InitiatingHeapOccupancyPercent=15",
+            "-XX:G1MixedGCLiveThresholdPercent=90",
+            "-XX:G1RSetUpdatingPauseTimePercent=5",
+            "-XX:SurvivorRatio=32",
+            "-XX:+PerfDisableSharedMem",
+            "-XX:MaxTenuringThreshold=1",
+        ]
+        .map(str::to_string)
+        .to_vec();
+
+        assert_eq!(jvm_gc_preset_args("g1gc", 21), expected);
+        assert_eq!(jvm_gc_preset_args("g1gc", 26), expected);
+    }
+
+    #[test]
+    fn jvm_gc_preset_args_keeps_shenandoah_independent_of_java_version() {
+        let expected = [
+            "-XX:+UseShenandoahGC",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+AlwaysPreTouch",
+            "-XX:+DisableExplicitGC",
+            "-XX:ShenandoahGCHeuristics=adaptive",
+        ]
+        .map(str::to_string)
+        .to_vec();
+
+        assert_eq!(jvm_gc_preset_args("shenandoah", 21), expected);
+        assert_eq!(jvm_gc_preset_args("shenandoah", 26), expected);
+    }
+
+    #[test]
+    fn jvm_gc_preset_args_returns_nothing_for_default_and_unknown_presets() {
+        assert!(jvm_gc_preset_args("default", 26).is_empty());
+        assert!(jvm_gc_preset_args("something-unknown", 26).is_empty());
+    }
+}

--- a/src-tauri/src/core/java/mod.rs
+++ b/src-tauri/src/core/java/mod.rs
@@ -4,6 +4,7 @@ use tauri::{AppHandle, Emitter, Manager};
 
 pub mod detection;
 pub mod error;
+pub mod launch_args;
 pub mod persistence;
 pub mod priority;
 pub mod provider;

--- a/src-tauri/src/core/java/validation.rs
+++ b/src-tauri/src/core/java/validation.rs
@@ -56,18 +56,20 @@ pub fn parse_version_string(output: &str) -> Option<String> {
 
 pub fn parse_java_version(version: &str) -> u32 {
     let parts: Vec<&str> = version.split('.').collect();
-    if let Some(first) = parts.first() {
-        // Handle both legacy (1.x) and modern (x) versioning
-        if *first == "1" {
-            // Legacy versioning
-            parts.get(1).and_then(|s| s.parse().ok()).unwrap_or(0)
-        } else {
-            // Modern versioning
-            first.parse().unwrap_or(0)
-        }
-    } else {
-        0
-    }
+    let major_component = match parts.first() {
+        Some(&"1") => parts.get(1).copied(),
+        Some(first) => Some(*first),
+        None => None,
+    };
+
+    major_component
+        .and_then(|component| {
+            let numeric_end = component
+                .find(|character: char| !character.is_ascii_digit())
+                .unwrap_or(component.len());
+            component[..numeric_end].parse().ok()
+        })
+        .unwrap_or(0)
 }
 
 pub fn extract_architecture(version_output: &str) -> String {
@@ -143,4 +145,34 @@ pub fn is_version_compatible(
         .unwrap_or(true);
     let meets_max = max_major_version.map(|m| major <= m).unwrap_or(true);
     meets_min && meets_max
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_java_version;
+
+    #[test]
+    fn parse_java_version_handles_modern_dotted_versions() {
+        assert_eq!(parse_java_version("21.0.8"), 21);
+        assert_eq!(parse_java_version("24.0.1"), 24);
+        assert_eq!(parse_java_version("26.0.2"), 26);
+    }
+
+    #[test]
+    fn parse_java_version_handles_early_access_suffixes() {
+        assert_eq!(parse_java_version("24-ea"), 24);
+        assert_eq!(parse_java_version("26-ea+10"), 26);
+    }
+
+    #[test]
+    fn parse_java_version_handles_legacy_versions() {
+        assert_eq!(parse_java_version("1.8.0_402"), 8);
+        assert_eq!(parse_java_version("1.8-ea"), 8);
+    }
+
+    #[test]
+    fn parse_java_version_returns_zero_for_unparseable_versions() {
+        assert_eq!(parse_java_version(""), 0);
+        assert_eq!(parse_java_version("ea"), 0);
+    }
 }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -365,6 +365,8 @@ async fn start_game(
         )
     );
 
+    let java_major =
+        core::java::validation::parse_java_version(&java_installation.version);
     let java_path_to_use = java_installation.path;
 
     // 2. Prepare download tasks
@@ -687,45 +689,10 @@ async fn start_game(
     args.push(format!("-Xms{}M", memory.applied_min_mb));
 
     // JVM GC preset args
-    match config.jvm_preset.as_str() {
-        "g1gc" => {
-            args.push("-XX:+UseG1GC".to_string());
-            args.push("-XX:+ParallelRefProcEnabled".to_string());
-            args.push("-XX:MaxGCPauseMillis=200".to_string());
-            args.push("-XX:+UnlockExperimentalVMOptions".to_string());
-            args.push("-XX:+DisableExplicitGC".to_string());
-            args.push("-XX:+AlwaysPreTouch".to_string());
-            args.push("-XX:G1NewSizePercent=30".to_string());
-            args.push("-XX:G1MaxNewSizePercent=40".to_string());
-            args.push("-XX:G1HeapRegionSize=8M".to_string());
-            args.push("-XX:G1ReservePercent=20".to_string());
-            args.push("-XX:G1HeapWastePercent=5".to_string());
-            args.push("-XX:G1MixedGCCountTarget=4".to_string());
-            args.push("-XX:InitiatingHeapOccupancyPercent=15".to_string());
-            args.push("-XX:G1MixedGCLiveThresholdPercent=90".to_string());
-            args.push("-XX:G1RSetUpdatingPauseTimePercent=5".to_string());
-            args.push("-XX:SurvivorRatio=32".to_string());
-            args.push("-XX:+PerfDisableSharedMem".to_string());
-            args.push("-XX:MaxTenuringThreshold=1".to_string());
-        }
-        "zgc" => {
-            args.push("-XX:+UseZGC".to_string());
-            args.push("-XX:+UnlockExperimentalVMOptions".to_string());
-            args.push("-XX:+ZGenerational".to_string());
-            args.push("-XX:+AlwaysPreTouch".to_string());
-            args.push("-XX:+DisableExplicitGC".to_string());
-        }
-        "shenandoah" => {
-            args.push("-XX:+UseShenandoahGC".to_string());
-            args.push("-XX:+UnlockExperimentalVMOptions".to_string());
-            args.push("-XX:+AlwaysPreTouch".to_string());
-            args.push("-XX:+DisableExplicitGC".to_string());
-            args.push("-XX:ShenandoahGCHeuristics=adaptive".to_string());
-        }
-        _ => {
-            // "default" — no extra GC args
-        }
-    }
+    args.extend(core::java::launch_args::jvm_gc_preset_args(
+        &config.jvm_preset,
+        java_major,
+    ));
 
     // Ensure natives path is set if not already in jvm args
     if !args.iter().any(|a| a.contains("-Djava.library.path")) {


### PR DESCRIPTION
## Summary

- make the ZGC JVM preset aware of the resolved Java major version
- preserve the existing ZGC flags and ordering on JDK 23 and older
- omit the removed `-XX:+ZGenerational` option on JDK 24 and newer
- support early-access and other suffixed Java versions such as `24-ea` and `26-ea+10`
- add focused unit coverage for the JDK 24 boundary and the Java 26 regression

## Root cause

JDK 24 removed the `ZGenerational` option when non-generational ZGC was removed. DropOut still added `-XX:+ZGenerational` unconditionally whenever the ZGC preset was selected, so Java 24 and newer fail during JVM creation with `Unrecognized VM option 'ZGenerational'`.

Early-access version strings also require special handling: the existing parser attempted to parse the entire first component, causing values such as `26-ea` to fall back to major version `0` and retain the removed flag.

## Implementation

- extract the existing G1GC, ZGC, and Shenandoah preset argument generation into a pure `jvm_gc_preset_args` helper
- reuse the canonical `core::java::validation::parse_java_version` parser on the Java installation selected by the normal launch resolution flow
- parse the leading numeric major from suffixed version components while preserving `0` for genuinely unparseable versions
- include `-XX:+ZGenerational` only when the resolved Java major is lower than 24
- keep Java detection, instance overrides, memory arguments, launch flow, configuration values, and frontend behavior unchanged

## Compatibility

- JDK 21 and 23 with ZGC: existing arguments are preserved, including `-XX:+ZGenerational`
- JDK 24, 26, early-access builds, and future versions with ZGC: `-XX:+UseZGC` and all other existing ZGC arguments remain; only `-XX:+ZGenerational` is omitted
- legacy `1.8.x` Java versions: continue to resolve to major version 8
- genuinely unparseable version strings: continue to resolve to major version `0`
- G1GC and Shenandoah: arguments and ordering are unchanged for every Java version
- default and unknown presets: no additional GC arguments are generated, matching the existing behavior

## Tests

The pure argument helper and canonical Java version parser are covered for:

- ZGC on Java 21, 23, 24, 26, `26-ea`, and a future Java 30
- suffixed versions including `24-ea`, `26-ea+10`, and legacy `1.8-ea`
- standard dotted versions and genuinely unparseable inputs
- G1GC and Shenandoah stability across Java 21 and 26
- default and unknown presets

## Validation

- `cargo test --manifest-path src-tauri/Cargo.toml parse_java_version -- --nocapture` — 4 passed
- `cargo test --manifest-path src-tauri/Cargo.toml jvm_gc_preset_args -- --nocapture` — 10 passed
- `cargo fmt --manifest-path src-tauri/Cargo.toml -- --check` — passed
- `cargo check --manifest-path src-tauri/Cargo.toml` — passed
- `cargo clippy --manifest-path src-tauri/Cargo.toml` — passed with existing baseline warnings only
- `cargo test --manifest-path src-tauri/Cargo.toml --verbose` — 322 passed, 1 ignored
- `cargo build --manifest-path src-tauri/Cargo.toml --verbose` — passed
- `git diff --check` — passed

## Release note

Adds a `dropout: "patch:fix"` changeset describing the JDK 24+ ZGC compatibility fix.

Closes #212.
